### PR TITLE
Update curl install instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ After running the installer, the system should be in the same state as it would 
 ## TL;DR:
 **WARNING:** doing this is potentially a security issue! You had better really trust us if you do this:
 ```bash
-curl https://raw.githubusercontent.com/tenstorrent/tt-installer/refs/heads/main/install.sh | sudo bash
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/tenstorrent/tt-installer/refs/heads/main/install.sh)"
 ```
 We would generally recommend other ways of doing this, noted below.
 


### PR DESCRIPTION
Instead of piping curl to bash, use curl in a subshell and then pass the script to bash as an argument.