### PR TITLE
Make reboot choices more flexible and introduce the idea of "modes"

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -77,7 +77,7 @@ CONTAINER_MODE=${TT_MODE_CONTAINER:-1}
 if [[ "${CONTAINER_MODE}" = "0" ]]; then
     SKIP_INSTALL_KMD=0
     SKIP_INSTALL_HUGEPAGES=0
-	REBOOT_OPTION=2 # Do not reboot
+    REBOOT_OPTION=2 # Do not reboot
 fi
 
 # Non-interactive mode flag (set to 0 to enable)

--- a/install.sh
+++ b/install.sh
@@ -60,8 +60,8 @@ PYTHON_CHOICE="${TT_PYTHON_CHOICE:-2}"
 declare -A PYTHON_CHOICE_TXT
 PYTHON_CHOICE_TXT[1]="Existing venv"
 PYTHON_CHOICE_TXT[2]="New venv"
-PYTHON_CHOICE_TXT[3]="pipx"
-PYTHON_CHOICE_TXT[4]="System Python"
+PYTHON_CHOICE_TXT[3]="System Python"
+PYTHON_CHOICE_TXT[4]="pipx"
 
 # Post-install reboot behavior
 # 1 = Ask the user, 2 = never, 3 = always
@@ -72,7 +72,7 @@ REBOOT_OPTION_TXT[2]="Never reboot"
 REBOOT_OPTION_TXT[3]="Always reboot"
 
 # Container mode flag (set to 0 to enable, which skips KMD and HugePages and never reboots)
-CONTAINER_MODE=${TT_CONTAINER_MODE:-1}
+CONTAINER_MODE=${TT_MODE_CONTAINER:-1}
 # If container mode is enabled, skip KMD and HugePages
 if [[ "${CONTAINER_MODE}" = "0" ]]; then
     SKIP_INSTALL_KMD=0
@@ -81,8 +81,8 @@ if [[ "${CONTAINER_MODE}" = "0" ]]; then
 fi
 
 # Non-interactive mode flag (set to 0 to enable)
-NON_INTERACTIVE=${TT_NON_INTERACTIVE:-1}
-if [[ "${NON_INTERACTIVE}" = "0" ]]; then
+NON_INTERATIVE_MODE=${TT_MODE_NON_INTERATIVE:-1}
+if [[ "${NON_INTERATIVE_MODE}" = "0" ]]; then
 	# In non-interactive mode, we can't ask the user for anything
 	# So if they don't provide a reboot choice we will pick a default
 	if [[ "${REBOOT_OPTION}" = "1" ]]; then
@@ -176,7 +176,7 @@ verify_download() {
 # Function to prompt for yes/no
 confirm() {
 	# In non-interactive mode, always return true
-	if [[ "${NON_INTERACTIVE}" = "0" ]]; then
+	if [[ "${NON_INTERATIVE_MODE}" = "0" ]]; then
 		return 0
 	fi
 
@@ -197,7 +197,7 @@ get_python_choice() {
 		log "Using Python installation method from environment variable (option ${PYTHON_CHOICE}: ${PYTHON_CHOICE_TXT[${PYTHON_CHOICE}]})"
 		return
 	# Otherwise, if in non-interactive mode, use the default
-	elif [[ "${NON_INTERACTIVE}" = "0" ]]; then
+	elif [[ "${NON_INTERATIVE_MODE}" = "0" ]]; then
 			log "Non-interactive mode, using default Python installation method (option ${PYTHON_CHOICE}: ${PYTHON_CHOICE_TXT[${PYTHON_CHOICE}]})"
 			return
 	fi
@@ -252,7 +252,7 @@ main() {
 	log "  System Tools: ${SYSTOOLS_VERSION}"
 
 	# Log special mode settings
-	if [[ "${NON_INTERACTIVE}" = "0" ]]; then
+	if [[ "${NON_INTERATIVE_MODE}" = "0" ]]; then
 		warn "Running in non-interactive mode"
 	fi
 	if [[ "${CONTAINER_MODE}" = "0" ]]; then
@@ -325,7 +325,7 @@ main() {
 			;;
 		3)
 			log "Using system pathing"
-			INSTALLED_IN_VENV=0
+			INSTALLED_IN_VENV=1
 			# If we're on a modern OS, specify we want to break sys packages
 			if [[ "${IS_UBUNTU_20}" != "0" ]]; then
 				PYTHON_INSTALL_CMD="pip install --break-system-packages"


### PR DESCRIPTION
    The TT_REBOOT_OPTION environment variable now has three options:
    1. Ask the user
    2. Never reboot
    3. Always reboot
    
    Container mode and non-interactive mode are now the last things
    evaluated, allowing them to have some special behavior. Non-interactive
    mode doesn't permit choice 2, for instance, since we can't ask the user for
    anything.

    We can introduce new modes if need be, which can set boolean or feature flags.