### PR TITLE
Add --all option to dkms remove command

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -535,7 +535,7 @@ main() {
 		if KMD_INSTALLED_VERSION=$(modinfo -F version tenstorrent 2>/dev/null); then
 			warn "Found active KMD module, version ${KMD_INSTALLED_VERSION}."
 			if confirm "Force KMD reinstall?"; then
-				sudo dkms remove "tenstorrent/${KMD_INSTALLED_VERSION}"
+				sudo dkms remove "tenstorrent/${KMD_INSTALLED_VERSION}" --all
 				git clone --branch "ttkmd-${KMD_VERSION}" https://github.com/tenstorrent/tt-kmd.git
 				sudo dkms add tt-kmd
 				sudo dkms install "tenstorrent/${KMD_VERSION}"


### PR DESCRIPTION
The dkms remove command requires either the `-k <kernel/arch>` option to specify a particular kernel version or the `--all` option to remove the module from all installed kernel versions. If neither is provided, the command fails with an error.

In this case, we should use `--all` to ensure the DKMS module is removed from all installed kernel versions.