### PR TITLE
Use GH API to fetch latest tag

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -18,27 +18,27 @@ EOF
 # ========================= GIT URLs =========================
 
 # Fetch latest kmd from git tags
-TT_KMD_GIT_URL="https://github.com/tenstorrent/tt-kmd.git"
+TT_KMD_GH_REPO="tenstorrent/tt-kmd"
 fetch_latest_kmd_version() {
 	local latest_kmd
-	latest_kmd=$(git ls-remote --tags --refs "${TT_KMD_GIT_URL}" | awk -F/ '{print $NF}' | sort -V | tail -n1)
+	latest_kmd=$(wget -qO- https://api.github.com/repos/${TT_KMD_GH_REPO}/releases/latest | jq -r '.tag_name')
 	echo "${latest_kmd#ttkmd-}"
 }
 
 # Fetch lastest FW version
-TT_FW_GIT_URL="https://github.com/tenstorrent/tt-firmware.git"
+TT_FW_GH_REPO="tenstorrent/tt-firmware"
 fetch_latest_fw_version() {
 	local latest_fw
-	latest_fw=$(git ls-remote --tags --refs "${TT_FW_GIT_URL}" | awk -F/ '{print $NF}' | sort -V | tail -n1)
+	latest_fw=$(wget -qO- https://api.github.com/repos/${TT_FW_GH_REPO}/releases/latest | jq -r '.tag_name')
 	echo "${latest_fw#v}" # Remove 'v' prefix if present
 }
 
 # Fetch latest systools version
-TT_SYSTOOLS_GIT_URL="https://github.com/tenstorrent/tt-system-tools.git"
+TT_SYSTOOLS_GH_REPO="tenstorrent/tt-system-tools"
 fetch_latest_systools_version() {
 	local latest_systools
-	latest_systools=$(git ls-remote --tags --refs "${TT_SYSTOOLS_GIT_URL}" | awk -F/ '{print $NF}' | sort -V | tail -n1)
-	echo "${latest_systools#v}" # Remove 'upstream/' prefix
+	latest_systools=$(wget -qO- https://api.github.com/repos/${TT_SYSTOOLS_GH_REPO}/releases/latest | jq -r '.tag_name')
+	echo "${latest_systools#v}" # Remove 'v' prefix if present
 }
 
 # ========================= Podman Metalium Settings =========================
@@ -444,22 +444,22 @@ main() {
 			sudo apt update
 			if [[ "${IS_UBUNTU_20}" = "0" ]]; then
 				# On Ubuntu 20, install python3-venv and don't install pipx
-				sudo apt install -y wget git python3-pip python3-venv dkms cargo rustc
+				sudo apt install -y wget git python3-pip python3-venv dkms cargo rustc jq
 			else
-				sudo apt install -y wget git python3-pip dkms cargo rustc pipx
+				sudo apt install -y wget git python3-pip dkms cargo rustc pipx jq
 			fi
 			;;
 		"debian")
 			# On Debian, packaged cargo and rustc are very old. Users must install them another way.
 			sudo apt update
-			sudo apt install -y wget git python3-pip dkms pipx
+			sudo apt install -y wget git python3-pip dkms pipx jq
 			;;
 		"fedora")
-			sudo dnf install -y wget git python3-pip python3-devel dkms cargo rust pipx
+			sudo dnf install -y wget git python3-pip python3-devel dkms cargo rust pipx jq
 			;;
 		"rhel"|"centos")
 			sudo dnf install -y epel-release
-			sudo dnf install -y wget git python3-pip python3-devel dkms cargo rust pipx
+			sudo dnf install -y wget git python3-pip python3-devel dkms cargo rust pipx jq
 			;;
 		*)
 			error "Unsupported distribution: ${DISTRO_ID}"


### PR DESCRIPTION
Fixes Issue in https://github.com/tenstorrent/tt-installer/issues/22

#### Note: tt-firmware will still fail to install until https://github.com/tenstorrent/tt-firmware/issues/16 is resolved.

Full Output

```
ubuntu@docker-wheel:~$ ./install.sh 
   __                  __                             __
  / /____  ____  _____/ /_____  _____________  ____  / /_
 / __/ _ \/ __ \/ ___/ __/ __ \/ ___/ ___/ _ \/ __ \/ __/
/ /_/  __/ / / (__  ) /_/ /_/ / /  / /  /  __/ / / / /_  
\__/\___/_/ /_/____/\__/\____/_/  /_/   \___/_/ /_/\__/  

[INFO] Welcome to tenstorrent!
[INFO] Log is at /tmp/tenstorrent_install_Q0ASFp/install.log
[INFO] This script will install drivers and tooling and properly configure your tenstorrent hardware.
OK to continue? [Y/n] Y

[INFO] Starting installation
[INFO] Using software versions:
[INFO]   KMD: 1.34
[INFO]   Firmware: 18.2.0
[INFO]   System Tools: 1.3.1
[INFO] Checking for sudo permissions... (may request password)
[INFO] Installing base packages

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Get:1 http://security.ubuntu.com/ubuntu jammy-security InRelease [129 kB]
Get:2 http://nova.clouds.archive.ubuntu.com/ubuntu jammy InRelease [270 kB]
Get:3 http://nova.clouds.archive.ubuntu.com/ubuntu jammy-updates InRelease [128 kB]
Get:4 http://nova.clouds.archive.ubuntu.com/ubuntu jammy-backports InRelease [127 kB]
Fetched 654 kB in 1s (529 kB/s)
Reading package lists...
Building dependency tree...
Reading state information...
53 packages can be upgraded. Run 'apt list --upgradable' to see them.

WARNING: apt does not have a stable CLI interface. Use with caution in scripts.

Reading package lists...
Building dependency tree...
Reading state information...
jq is already the newest version (1.6-2.1ubuntu3).
pipx is already the newest version (1.0.0-1).
dkms is already the newest version (2.8.7-2ubuntu2.2).
git is already the newest version (1:2.34.1-1ubuntu1.12).
rustc is already the newest version (1.75.0+dfsg0ubuntu1~bpo0-0ubuntu0.22.04).
wget is already the newest version (1.21.2-2ubuntu1.1).
cargo is already the newest version (1.75.0+dfsg0ubuntu1~bpo0-0ubuntu0.22.04).
python3-pip is already the newest version (22.0.2+dfsg-1ubuntu0.5).
0 upgraded, 0 newly installed, 0 to remove and 53 not upgraded.
[INFO] Would you like to install the TT-Metalium library using Podman?
Make a selection [Y/n] n

[INFO] How would you like to install Python packages?
1. Use the active virtual environment
2. [DEFAULT] Create a new Python virtual environment (venv) at /home/ubuntu/.tenstorrent-venv
3. Use the system pathing, available for multiple users. *** NOT RECOMMENDED UNLESS YOU ARE SURE ***
4. Use pipx for isolated package installation
Enter your choice (1, 2...) or press enter for default: 2

[INFO] Setting up new Python virtual environment
[INFO] Installing Kernel-Mode Driver
[WARNING] Found active KMD module, version 1.34.
Force KMD reinstall? [Y/n] Y

Module tenstorrent-1.34 for kernel 5.15.0-135-generic (x86_64).
Before uninstall, this module version was ACTIVE on this kernel.

tenstorrent.ko:
 - Uninstallation
   - Deleting from: /lib/modules/5.15.0-135-generic/updates/dkms/
 - Original module
   - No original module was found for this module on this kernel.
   - Use the dkms install command to reinstall any previous module version.

depmod...
Deleting module tenstorrent-1.34 completely from the DKMS tree.
Cloning into 'tt-kmd'...
Note: switching to 'ccb04da454dcc40ecc2a9bf63c06a18ffac8b8fb'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by switching back to a branch.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -c with the switch command. Example:

  git switch -c <new-branch-name>

Or undo this operation with:

  git switch -

Turn off this advice by setting config variable advice.detachedHead to false

Creating symlink /var/lib/dkms/tenstorrent/1.34/source -> /usr/src/tenstorrent-1.34

Kernel preparation unnecessary for this kernel. Skipping...

Building module:
cleaning build area...
make -j14 KERNELRELEASE=5.15.0-135-generic -C /lib/modules/5.15.0-135-generic/build M=/var/lib/dkms/tenstorrent/1.34/build...
Signing module:
 - /var/lib/dkms/tenstorrent/1.34/5.15.0-135-generic/x86_64/module/tenstorrent.ko
EFI variables are not supported on this system
/sys/firmware/efi/efivars not found, aborting.
cleaning build area...

tenstorrent.ko:
Running module version sanity check.
 - Original module
   - No original module exists within this kernel
 - Installation
   - Installing to /lib/modules/5.15.0-135-generic/updates/dkms/

Running the post_install script:

depmod...
[INFO] Installing TT-Flash and updating firmware
Collecting git+https://github.com/tenstorrent/tt-flash.git
  Cloning https://github.com/tenstorrent/tt-flash.git to /tmp/pip-req-build-15dia2ho
  Running command git clone --filter=blob:none --quiet https://github.com/tenstorrent/tt-flash.git /tmp/pip-req-build-15dia2ho
  Resolved https://github.com/tenstorrent/tt-flash.git to commit 43acd96831fbdce3954dbe757ddf0ed310be6b61
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting pyluwen@ git+https://github.com/tenstorrent/luwen.git@v0.6.4#subdirectory=crates/pyluwen
  Cloning https://github.com/tenstorrent/luwen.git (to revision v0.6.4) to /tmp/pip-install-7xfgcyim/pyluwen_3f26072c1b814fac9162277a47b21bbe
  Running command git clone --filter=blob:none --quiet https://github.com/tenstorrent/luwen.git /tmp/pip-install-7xfgcyim/pyluwen_3f26072c1b814fac9162277a47b21bbe
  Running command git checkout -q ffbd31ac811e89e6a5a952f9b04eaaac397d3afe
  Resolved https://github.com/tenstorrent/luwen.git to commit ffbd31ac811e89e6a5a952f9b04eaaac397d3afe
  Running command git submodule update --init --recursive -q
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Collecting tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14
  Cloning https://github.com/tenstorrent/tt-tools-common.git (to revision v1.4.14) to /tmp/pip-install-7xfgcyim/tt-tools-common_19a1458156a444799504da680f88d4b2
  Running command git clone --filter=blob:none --quiet https://github.com/tenstorrent/tt-tools-common.git /tmp/pip-install-7xfgcyim/tt-tools-common_19a1458156a444799504da680f88d4b2
  Running command git checkout -q 176cfa7a2792511237ecfb4c071393885a4e84d0
  Resolved https://github.com/tenstorrent/tt-tools-common.git to commit 176cfa7a2792511237ecfb4c071393885a4e84d0
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'done'
Requirement already satisfied: pyyaml==6.0.1 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-flash==3.3.1) (6.0.1)
Requirement already satisfied: tomli==2.0.1 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-flash==3.3.1) (2.0.1)
Requirement already satisfied: tabulate==0.9.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-flash==3.3.1) (0.9.0)
Requirement already satisfied: requests==2.32.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (2.32.0)
Requirement already satisfied: rich==13.7.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (13.7.0)
Requirement already satisfied: distro==1.8.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (1.8.0)
Requirement already satisfied: textual==0.59.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (0.59.0)
Requirement already satisfied: pydantic>=1.2 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (2.11.4)
Requirement already satisfied: psutil==5.9.6 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (5.9.6)
Requirement already satisfied: tqdm==4.66.3 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (4.66.3)
Requirement already satisfied: elasticsearch==8.11.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (8.11.0)
Requirement already satisfied: elastic-transport<9,>=8 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from elasticsearch==8.11.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (8.17.1)
Requirement already satisfied: certifi>=2017.4.17 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from requests==2.32.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (2025.4.26)
Requirement already satisfied: charset-normalizer<4,>=2 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from requests==2.32.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (3.4.2)
Requirement already satisfied: urllib3<3,>=1.21.1 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from requests==2.32.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (2.4.0)
Requirement already satisfied: idna<4,>=2.5 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from requests==2.32.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (3.10)
Requirement already satisfied: pygments<3.0.0,>=2.13.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from rich==13.7.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (2.19.1)
Requirement already satisfied: markdown-it-py>=2.2.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from rich==13.7.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (3.0.0)
Requirement already satisfied: typing-extensions<5.0.0,>=4.4.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from textual==0.59.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (4.13.2)
Requirement already satisfied: typing-inspection>=0.4.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from pydantic>=1.2->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (0.4.0)
Requirement already satisfied: annotated-types>=0.6.0 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from pydantic>=1.2->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (0.7.0)
Requirement already satisfied: pydantic-core==2.33.2 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from pydantic>=1.2->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (2.33.2)
Requirement already satisfied: mdurl~=0.1 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from markdown-it-py>=2.2.0->rich==13.7.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (0.1.2)
Requirement already satisfied: mdit-py-plugins in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from markdown-it-py>=2.2.0->rich==13.7.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (0.4.2)
Requirement already satisfied: linkify-it-py<3,>=1 in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from markdown-it-py>=2.2.0->rich==13.7.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (2.0.3)
Requirement already satisfied: uc-micro-py in /home/ubuntu/.tenstorrent-venv/lib/python3.10/site-packages (from linkify-it-py<3,>=1->markdown-it-py>=2.2.0->rich==13.7.0->tt-tools-common@ git+https://github.com/tenstorrent/tt-tools-common.git@v1.4.14->tt-flash==3.3.1) (1.0.3)
--2025-05-07 23:29:39--  https://github.com/tenstorrent/tt-firmware/raw/main/fw_pack-18.2.0.fwbundle
Resolving github.com (github.com)... 140.82.112.3
Connecting to github.com (github.com)|140.82.112.3|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2025-05-07 23:29:39 ERROR 404: Not Found.

```