### PR TITLE
Ignore 'linux-image-virtual' on Ubuntu based setups

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -61,7 +61,7 @@ KERNEL_LISTING_DEBIAN=$( cat << EOF
 	grep linux-image |
 	awk 'BEGIN { FS="/"; } { print \$1; }' |
 	sed 's/^linux-image-//g' |
-	grep -v "^generic$\|^generic-hwe-[0-9]\{2,\}\.[0-9]\{2,\}$"
+	grep -v "^generic$\|^generic-hwe-[0-9]\{2,\}\.[0-9]\{2,\}$\|virtual"
 EOF
 )
 
@@ -70,7 +70,7 @@ KERNEL_LISTING_UBUNTU=$( cat << EOF
 	grep linux-image |
 	awk 'BEGIN { FS="/"; } { print \$1; }' |
 	sed 's/^linux-image-//g' |
-	grep -v "^generic$\|^generic-hwe-[0-9]\{2,\}\.[0-9]\{2,\}$"
+	grep -v "^generic$\|^generic-hwe-[0-9]\{2,\}\.[0-9]\{2,\}$\|virtual"
 EOF
 )
 KERNEL_LISTING_FEDORA="rpm -qa | grep \"^kernel.*-devel\" | grep -v \"\-devel-matched\" | sed 's/^kernel-devel-//'"


### PR DESCRIPTION
So from our perspective linux-image-virtual means nothing, not sure why it doesn't show up for us in the other testing but some users tripped over it.  Easy fix to just drop it here.