### PR TITLE
Install SFPI if not installing container

### DIFF
--- a/.github/workflows/build-test-installer.yml
+++ b/.github/workflows/build-test-installer.yml
@@ -104,6 +104,7 @@ jobs:
             export TT_INSTALL_HUGEPAGES=1
             export TT_UPDATE_FIRMWARE=1
             export TT_INSTALL_METALIUM_CONTAINER=1
+            export TT_SFPI_INSTALL=1
             export TT_PYTHON_CHOICE=new-venv
             export TT_REBOOT_OPTION=never
 
@@ -163,6 +164,7 @@ jobs:
             export TT_INSTALL_HUGEPAGES=1
             export TT_UPDATE_FIRMWARE=1
             export TT_INSTALL_METALIUM_CONTAINER=1
+            export TT_SFPI_INSTALL=1
             export TT_PYTHON_CHOICE=new-venv
             export TT_REBOOT_OPTION=never
 
@@ -230,6 +232,7 @@ jobs:
         export TT_SKIP_UPDATE_FIRMWARE=0
         export TT_SKIP_INSTALL_PODMAN=0
         export TT_SKIP_INSTALL_METALIUM_CONTAINER=0
+        export TT_SKIP_INSTALL_SFPI=0
         export TT_PYTHON_CHOICE=3
         export TT_REBOOT_OPTION=2
         export TT_MODE_CONTAINER=0


### PR DESCRIPTION
This PR adds SFPI to the installer and enables it by default unless the container is installed.

As far as I understand, SFPI needs to be present in order to use `tt-metal` or `ttnn`. It is included by default in the docker images but not installed through the install script. Including it here removes one additional manual configuration step.

EDIT: Rebased to depend on the `protoc` PR since it fixes another issue with `pyluwen`:

- https://github.com/tenstorrent/tt-installer/pull/64

Related:

- https://github.com/tenstorrent/tt-metal/issues/18293#issue-2878911022

---

NOTE: This PR will fail the CI build because `tt-smi` released `3.0.26` which [bumps pyluwen](https://github.com/tenstorrent/tt-smi/commit/cb5ef05538a7d03c06ae5efa769c556592019219#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R31) to `0.7.10` which triggers:

-  https://github.com/tenstorrent/luwen/issues/91

Apparently that was supposed to be fixed in:

- https://github.com/tenstorrent/luwen/pull/92

So it seems like a regression with the lock version CC @sbansalTT @warthog9

The CI build will succeed if specifying `--smi-version=v3.0.25`.

---

You can see the failing CI log [here](https://github.com/silvanshade/tt-installer/actions/runs/16662920797/job/47163775532) until the workflow is approved:

```
Collecting pyluwen@ git+https://github.com/tenstorrent/luwen.git@v0.7.10#subdirectory=crates/pyluwen (from tt-smi==3.0.26)
  Cloning https://github.com/tenstorrent/luwen.git (to revision v0.7.10) to /tmp/pip-install-cj4e8xlg/pyluwen_f748ac57495445aca6e215d906bf4453
  Running command git clone --filter=blob:none --quiet https://github.com/tenstorrent/luwen.git /tmp/pip-install-cj4e8xlg/pyluwen_f748ac57495445aca6e215d906bf4453
  Running command git checkout -q 7dba8ac349b8fde244033dee01843ffc13906564
  Resolved https://github.com/tenstorrent/luwen.git to commit 7dba8ac349b8fde244033dee01843ffc13906564
  Running command git submodule update --init --recursive -q
  Installing build dependencies: started
  Installing build dependencies: finished with status 'done'
  Getting requirements to build wheel: started
  Getting requirements to build wheel: finished with status 'done'
  Preparing metadata (pyproject.toml): started
  Preparing metadata (pyproject.toml): finished with status 'error'
  error: subprocess-exited-with-error
  
  × Preparing metadata (pyproject.toml) did not run successfully.
  │ exit code: 1
  ╰─> [10 lines of output]
      error: failed to parse lock file at: /tmp/pip-install-cj4e8xlg/pyluwen_f748ac57495445aca6e215d906bf4453/Cargo.lock
      
      Caused by:
        lock file version 4 requires `-Znext-lockfile-bump`
      💥 maturin failed
        Caused by: Cargo metadata failed. Does your crate compile with `cargo build`?
        Caused by: `cargo metadata` exited with an error:
      Error running maturin: Command '['maturin', 'pep517', 'write-dist-info', '--metadata-directory', '/tmp/pip-modern-metadata-w0_pcj81', '--interpreter', '/home/testuser/.tenstorrent-venv/bin/python3']' returned non-zero exit status 1.
      Checking for Rust toolchain....
      Running `maturin pep517 write-dist-info --metadata-directory /tmp/pip-modern-metadata-w0_pcj81 --interpreter /home/testuser/.tenstorrent-venv/bin/python3`
      [end of output]
```
