### PR TITLE
Install protobuf-compiler with base packages

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -740,25 +740,25 @@ main() {
 			sudo apt update
 			if [[ "${IS_UBUNTU_20}" = "0" ]]; then
 				# On Ubuntu 20, install python3-venv and don't install pipx
-				sudo apt install -y git python3-pip python3-venv dkms cargo rustc jq
+				sudo apt install -y git python3-pip python3-venv dkms cargo rustc jq protobuf-compiler
 			else
-				sudo DEBIAN_FRONTEND=noninteractive apt install -y git python3-pip dkms cargo rustc pipx jq
+				sudo DEBIAN_FRONTEND=noninteractive apt install -y git python3-pip dkms cargo rustc pipx jq protobuf-compiler
 			fi
 			KERNEL_LISTING="${KERNEL_LISTING_UBUNTU}"
 			;;
 		"debian")
 			# On Debian, packaged cargo and rustc are very old. Users must install them another way.
 			sudo apt update
-			sudo apt install -y git python3-pip dkms pipx jq
+			sudo apt install -y git python3-pip dkms pipx jq protobuf-compiler
 			KERNEL_LISTING="${KERNEL_LISTING_DEBIAN}"
 			;;
 		"fedora")
-			sudo dnf install -y git python3-pip python3-devel dkms cargo rust pipx jq
+			sudo dnf install -y git python3-pip python3-devel dkms cargo rust pipx jq protobuf-compiler
 			KERNEL_LISTING="${KERNEL_LISTING_FEDORA}"
 			;;
 		"rhel"|"centos")
 			sudo dnf install -y epel-release
-			sudo dnf install -y git python3-pip python3-devel dkms cargo rust pipx jq
+			sudo dnf install -y git python3-pip python3-devel dkms cargo rust pipx jq protobuf-compiler
 			KERNEL_LISTING="${KERNEL_LISTING_EL}"
 			;;
 		*)


### PR DESCRIPTION
The updated `pyluwen` transitive dependency from the `tt-smi` release `3.0.26` causes some of the CI jobs to fail with an error about missing `protoc` when installing `tt-smi`.

This PR ensures that `protoc` is installed (through `protobuf-compiler`) with the other base packages.

See example logs of the failure [here](https://github.com/silvanshade/tt-installer/actions/runs/16664316725/job/47167617193):

```
error: failed to run custom build command for `luwen-if v0.7.10 (/tmp/pip-install-gbjodvti/pyluwen_b9f7ac9deee24a2786dfdcbfd891e001/crates/luwen-if)`
      
Caused by:
  process didn't exit successfully: `/tmp/pip-install-gbjodvti/pyluwen_b9f7ac9deee24a2786dfdcbfd891e001/target/release/build/luwen-if-86ce687a73b3b108/build-script-build` (exit status: 1)
  --- stderr
  Error: Custom { kind: NotFound, error: "Could not find `protoc`. If `protoc` is installed, try setting the `PROTOC` environment variable to the path of the `protoc` binary. To install it on Debian, run `apt-get install protobuf-compiler`. It is also available at https://github.com/protocolbuffers/protobuf/releases  For more information: https://docs.rs/prost-build/#sourcing-protoc" }
warning: build failed, waiting for other jobs to finish...
💥 maturin failed
  Caused by: Failed to build a native library through cargo
  Caused by: Cargo build finished with "exit status: 101": `env -u CARGO PYO3_ENVIRONMENT_SIGNATURE="cpython-3.13-64bit" PYO3_PYTHON="/home/testuser/.tenstorrent-venv/bin/python3" PYTHON_SYS_EXECUTABLE="/home/testuser/.tenstorrent-venv/bin/python3" "cargo" "rustc" "--features" "pyo3/extension-module" "--message-format" "json-render-diagnostics" "--manifest-path" "/tmp/pip-install-gbjodvti/pyluwen_b9f7ac9deee24a2786dfdcbfd891e001/crates/pyluwen/Cargo.toml" "--release" "--lib"`
Error: command ['maturin', 'pep517', 'build-wheel', '-i', '/home/testuser/.tenstorrent-venv/bin/python3', '--compatibility', 'off'] returned non-zero exit status 1
[end of output]
```

Related:
-  #63 (other build issues with `tt-smi` release `3.0.26`)
- https://github.com/tenstorrent/tt-metal/issues/18293#issue-2878911022