### PR TITLE
Add podman-docker to Podman install

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -527,13 +527,13 @@ install_podman() {
 	# Install Podman using package manager
 	case "${DISTRO_ID}" in
 		"ubuntu"|"debian")
-			sudo apt install -y podman
+			sudo apt install -y podman podman-docker
 			;;
 		"fedora")
-			sudo dnf install -y podman
+			sudo dnf install -y podman podman-docker
 			;;
 		"rhel"|"centos")
-			sudo dnf install -y podman
+			sudo dnf install -y podman podman-docker
 			;;
 		*)
 			error "Unsupported distribution for Podman installation: ${DISTRO_ID}"


### PR DESCRIPTION
Users who use tt-installer and then use tt-inference-server will experience errors because tt-inference-server uses Docker and we install podman. To fix this, let's have Podman emulate Docker.