### PR TITLE
Add new SFPI file name format based on v6.21.0 for downloading SFPI package

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -762,7 +762,14 @@ install_sfpi() {
 
 	SFPI_FILE="sfpi-${SFPI_FILE_ARCH}_Linux.${SFPI_FILE_EXT}"
 
-	curl -fsSLO "${SFPI_RELEASE_URL}/${SFPI_VERSION}/${SFPI_FILE}"
+	if curl -fsLO "${SFPI_RELEASE_URL}/${SFPI_VERSION}/${SFPI_FILE}"; then
+        log "Successfully downloaded SFPI package"
+    else
+        warn "SFPI package is not found, retrying download with alternative link"
+        SFPI_FILE="sfpi_${SFPI_VERSION:1}_${SFPI_FILE_ARCH}.${SFPI_FILE_EXT}" # New file name format based on v 6.21.0
+        curl -fsSLO "${SFPI_RELEASE_URL}/${SFPI_VERSION}/${SFPI_FILE}"
+    fi
+
 	verify_download "${SFPI_FILE}"
 
 	case "${SFPI_FILE_EXT}" in


### PR DESCRIPTION
The latest version of SFPI ([v6.21.0](https://github.com/tenstorrent/sfpi/releases/tag/v6.21.0)) have new format for the package name. 

Instead of `sfpi-x86_64_Linux.deb`, it explicitly carries the version number and changes the dash into underscore (i.e., `sfpi_6.21.0_x86_64.deb`). This causes issue when running the `installer.sh` from `tt-installer` as `curl `cannot find the correct path for SFPI package to download. 

I modified the name format to match the newest SFPI naming scheme while still maintaining support for legacy (older) SFPI package naming scheme. 
