### PR TITLE
Create beta repository mode

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -877,7 +877,7 @@ manual_install_sfpi() {
 }
 
 install_tt_repos () {
-	info "Installing TT repositories to your distribution package manager"
+	log "Installing TT repositories to your distribution package manager"
 	case "${DISTRO_ID}" in
 		"ubuntu"|"debian")
 			# Add the apt listing
@@ -903,7 +903,7 @@ install_tt_repos () {
 }
 
 install_sw_from_repos () {
-	info "Installing software from TT repositories"
+	log "Installing software from TT repositories"
 	case "${DISTRO_ID}" in
 		"ubuntu"|"debian")
 			# For now, install the big three

--- a/install.m4
+++ b/install.m4
@@ -1207,11 +1207,11 @@ main() {
 		fi
 	fi
 
-	if [[ ${INSTALL_TT_REPOS} = "on" ]]; then
+	if [[ ${INSTALL_TT_REPOS:-} = "on" ]]; then
 		install_tt_repos
 	fi
 
-	if [[ ${INSTALL_SW_FROM_REPOS} = "on" ]]; then
+	if [[ ${INSTALL_SW_FROM_REPOS:-} = "on" ]]; then
 		install_sw_from_repos
 	fi
 

--- a/install.m4
+++ b/install.m4
@@ -745,7 +745,7 @@ get_podman_metalium_choice() {
 	fi
 }
 
-build_install_kmd() {
+manual_install_kmd() {
 log "Installing Kernel-Mode Driver"
 	cd "${WORKDIR}"
 	# Get the KMD version, if installed, while silencing errors
@@ -784,7 +784,7 @@ log "Installing Kernel-Mode Driver"
 	fi
 }
 
-build_install_hugepages() {
+manual_install_hugepages() {
 	log "Setting up HugePages"
 	BASE_TOOLS_URL="https://github.com/tenstorrent/tt-system-tools/releases/download"
 	case "${DISTRO_ID}" in
@@ -819,7 +819,7 @@ build_install_hugepages() {
 }
 
 # Function to install SFPI
-install_sfpi() {
+manual_install_sfpi() {
 	log "Installing SFPI"
 	local arch
 	local SFPI_RELEASE_URL="https://github.com/tenstorrent/sfpi/releases/download"
@@ -1103,7 +1103,7 @@ main() {
 	if [[ "${_arg_install_kmd}" = "off" ]]; then
 		log "Skipping KMD installation"
 	else
-		build_install_kmd
+		manual_install_kmd
 	fi
 
 	# Install TT-Flash and Firmware
@@ -1170,7 +1170,7 @@ main() {
 	if [[ "${_arg_install_hugepages}" = "off" ]]; then
 		warn "Skipping HugePages setup"
 	else
-		build_install_hugepages
+		manual_install_hugepages
 	fi
 
 	# Install TT-SMI
@@ -1215,7 +1215,7 @@ main() {
 	fi
 
 	if [[ "${_arg_install_sfpi}" = "on" ]]; then
-		install_sfpi
+		manual_install_sfpi
 	fi
 
 	if [[ "${INSTALLED_IN_VENV}" = "0" ]]; then

--- a/install.m4
+++ b/install.m4
@@ -188,6 +188,7 @@ fi
 
 # For the repository mode beta, we will disable the existing install functions
 # and call a new function which installs the dependencies using the APT repo.
+# shellcheck disable=SC2154
 if [[ "${_arg_mode_repository_beta}" = "on" ]]; then
 	_arg_install_hugepages="off"
 	_arg_install_sfpi="off"

--- a/install.m4
+++ b/install.m4
@@ -461,6 +461,7 @@ fetch_tt_sw_versions() {
 		"TT_SYSTOOLS_VERSION:_arg_systools_version:SYSTOOLS_VERSION:System Tools:${TT_SYSTOOLS_GH_REPO}:v"
 		"TT_SMI_VERSION:_arg_smi_version:SMI_VERSION:tt-smi:${TT_SMI_GH_REPO}:"
 		"TT_FLASH_VERSION:_arg_flash_version:FLASH_VERSION:tt-flash:${TT_FLASH_GH_REPO}:"
+		"TT_SFPI_VERSION:_arg_sfpi_version:SFPI_VERSION:SFPI:${TT_SFPI_GH_REPO}:v"
 	)
 	
 	# Process each component
@@ -496,7 +497,8 @@ fetch_tt_sw_versions() {
 	      -n "${FW_VERSION}" && "${FW_VERSION}" != "null" && \
 	      -n "${SYSTOOLS_VERSION}" && "${SYSTOOLS_VERSION}" != "null" && \
 	      -n "${SMI_VERSION}" && "${SMI_VERSION}" != "null" && \
-	      -n "${FLASH_VERSION}" && "${FLASH_VERSION}" != "null" ]]; then
+	      -n "${FLASH_VERSION}" && "${FLASH_VERSION}" != "null" && \
+	      -n "${SFPI_VERSION}" && "${SFPI_VERSION}" != "null" ]]; then
 		HAVE_SET_TT_SW_VERSIONS=0
 		log "Using software versions:"
 		log "  TT-KMD: ${KMD_VERSION}"
@@ -504,6 +506,7 @@ fetch_tt_sw_versions() {
 		log "  System Tools: ${SYSTOOLS_VERSION}"
 		log "  tt-smi: ${SMI_VERSION#v}"
 		log "  tt-flash: ${FLASH_VERSION#v}"
+		log "  SFPI: ${SFPI_VERSION#v}"
 	else
 		HAVE_SET_TT_SW_VERSIONS=1
 		error "*** Software versions are empty or null after successful fetch!"
@@ -512,6 +515,7 @@ fetch_tt_sw_versions() {
 		error "  System Tools: '${SYSTOOLS_VERSION}'"
 		error "  tt-smi: '${SMI_VERSION}'"
 		error "  tt-flash: '${FLASH_VERSION}'"
+		error "  SFPI: '${SFPI_VERSION}'"
 		error "This may indicate an issue with the GitHub API responses."
 		error_exit "Visit https://github.com/tenstorrent/tt-installer/wiki/Common-Problems#software-versions-are-empty-or-null for a fix."
 	fi
@@ -842,6 +846,7 @@ install_sfpi() {
 	esac
 
 	SFPI_FILE="sfpi_${SFPI_VERSION}_${SFPI_FILE_ARCH}.${SFPI_FILE_EXT}"
+	log "Downloading ${SFPI_FILE}"
 
 	curl -fsSLO "${SFPI_RELEASE_URL}/v${SFPI_VERSION}/${SFPI_FILE}"
 	verify_download "${SFPI_FILE}"
@@ -1147,20 +1152,6 @@ main() {
 	fi
 
 	if [[ "${_arg_install_sfpi}" = "on" ]]; then
-		if [[ -n "${TT_SFPI_VERSION:-}" ]]; then
-			SFPI_VERSION="${TT_SFPI_VERSION}"
-		elif [[ -n "${_arg_sfpi_version}" ]]; then
-			SFPI_VERSION="${_arg_sfpi_version}"
-		else
-			if SFPI_VERSION=$(fetch_latest_version "${TT_SFPI_GH_REPO}" "v"); then
-				: # Success, SFPI_VERSION is set
-			else
-				local sfpi_exit_code=$?
-				handle_version_fetch_error "SFPI" "${sfpi_exit_code}" "${TT_SFPI_GH_REPO}"
-				error_exit "Failed to fetch SFPI version. Installation cannot continue."
-			fi
-		fi
-		log "SFPI Version: ${SFPI_VERSION}"
 		install_sfpi
 	fi
 

--- a/install.m4
+++ b/install.m4
@@ -881,6 +881,7 @@ install_tt_repos () {
 	case "${DISTRO_ID}" in
 		"ubuntu"|"debian")
 			# Add the apt listing
+			# shellcheck disable=2002
 			echo "deb [signed-by=/etc/apt/keyrings/tt-pkg-key.asc] https://ppa.tenstorrent.com/ubuntu/ $( cat /etc/os-release | grep "^VERSION_CODENAME=" | sed 's/^VERSION_CODENAME=//' ) main" | sudo tee /etc/apt/sources.list.d/tenstorrent.list > /dev/null
 
 			# Setup the keyring

--- a/install.m4
+++ b/install.m4
@@ -49,6 +49,7 @@ exit 11 #)
 # ARG_OPTIONAL_BOOLEAN([mode-container],,[Enable container mode (skips KMD, HugePages, and SFPI, never reboots)],[off])
 # ARG_OPTIONAL_BOOLEAN([mode-non-interactive],,[Enable non-interactive mode (no user prompts)],[off])
 # ARG_OPTIONAL_BOOLEAN([verbose],,[Enable verbose output for debugging])
+# ARG_OPTIONAL_BOOLEAN([mode-repository],,[BETA: Use external repository for package installation.],[off])
 
 # ARGBASH_GO
 
@@ -730,6 +731,45 @@ get_podman_metalium_choice() {
 	fi
 }
 
+build_install_kmd() {
+log "Installing Kernel-Mode Driver"
+	cd "${WORKDIR}"
+	# Get the KMD version, if installed, while silencing errors
+	if KMD_INSTALLED_VERSION=$(modinfo -F version tenstorrent 2>/dev/null); then
+		warn "Found active KMD module, version ${KMD_INSTALLED_VERSION}."
+		if confirm "Force KMD reinstall?"; then
+			sudo dkms remove "tenstorrent/${KMD_INSTALLED_VERSION}" --all
+			git clone --branch "ttkmd-${KMD_VERSION}" https://github.com/tenstorrent/tt-kmd.git
+			sudo dkms add tt-kmd
+			sudo dkms install "tenstorrent/${KMD_VERSION}"
+			sudo modprobe tenstorrent
+		else
+			warn "Skipping KMD installation"
+		fi
+	else
+		# Only install KMD if it's not already installed
+		git clone --branch "ttkmd-${KMD_VERSION}" https://github.com/tenstorrent/tt-kmd.git
+		sudo dkms add tt-kmd
+		# Ok so this gets exciting fast, so hang on for a second while I explain
+		# During the offline installer we need to figure out what kernels are actually installed
+		# because the kernel running on the system is not what we just installed and it's going
+		# to complain up a storm if we don't have the headers for the running kernel, which we don't
+		# so lets start by figuring out what kernels we do have (packaging, we can do this by doing a
+		# ls on /lib/modules too but right now I'm doing it this way, deal.
+		# Then we wander through and do dkms for the installed kernels only.  After that instead of
+		# trying to modprobe the module on a system we might not have built for, we check if we match
+		# and only then try modprobe
+		for x in $( eval "${KERNEL_LISTING}" )
+		do
+			sudo dkms install "tenstorrent/${KMD_VERSION}" -k "${x}"
+			if [[ "$( uname -r )" == "${x}" ]]
+			then
+				sudo modprobe tenstorrent
+			fi
+		done
+	fi
+}
+
 # Function to install SFPI
 install_sfpi() {
 	log "Installing SFPI"
@@ -969,42 +1009,7 @@ main() {
 	if [[ "${_arg_install_kmd}" = "off" ]]; then
 		log "Skipping KMD installation"
 	else
-		log "Installing Kernel-Mode Driver"
-		cd "${WORKDIR}"
-		# Get the KMD version, if installed, while silencing errors
-		if KMD_INSTALLED_VERSION=$(modinfo -F version tenstorrent 2>/dev/null); then
-			warn "Found active KMD module, version ${KMD_INSTALLED_VERSION}."
-			if confirm "Force KMD reinstall?"; then
-				sudo dkms remove "tenstorrent/${KMD_INSTALLED_VERSION}" --all
-				git clone --branch "ttkmd-${KMD_VERSION}" https://github.com/tenstorrent/tt-kmd.git
-				sudo dkms add tt-kmd
-				sudo dkms install "tenstorrent/${KMD_VERSION}"
-				sudo modprobe tenstorrent
-			else
-				warn "Skipping KMD installation"
-			fi
-		else
-			# Only install KMD if it's not already installed
-			git clone --branch "ttkmd-${KMD_VERSION}" https://github.com/tenstorrent/tt-kmd.git
-			sudo dkms add tt-kmd
-			# Ok so this gets exciting fast, so hang on for a second while I explain
-			# During the offline installer we need to figure out what kernels are actually installed
-			# because the kernel running on the system is not what we just installed and it's going
-			# to complain up a storm if we don't have the headers for the running kernel, which we don't
-			# so lets start by figuring out what kernels we do have (packaging, we can do this by doing a
-			# ls on /lib/modules too but right now I'm doing it this way, deal.
-			# Then we wander through and do dkms for the installed kernels only.  After that instead of
-			# trying to modprobe the module on a system we might not have built for, we check if we match
-			# and only then try modprobe
-			for x in $( eval "${KERNEL_LISTING}" )
-			do
-				sudo dkms install "tenstorrent/${KMD_VERSION}" -k "${x}"
-				if [[ "$( uname -r )" == "${x}" ]]
-				then
-					sudo modprobe tenstorrent
-				fi
-			done
-		fi
+		build_install_kmd
 	fi
 
 	# Install TT-Flash and Firmware


### PR DESCRIPTION
This is implemented by disabling existing install functions, adding the repos, and installing the "big three" (KMD, SFPI, Hugepages) via those repos. This is intended as a "step 1" which we can build from.