### PR TITLE
Reverting part of 95eaa4e

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -808,8 +808,14 @@ manual_install_hugepages() {
 			sudo dpkg -i "${TOOLS_FILENAME}"
 			if [[ "${SYSTEMD_NO}" != 0 ]]
 			then
-				sudo systemctl enable "${SYSTEMD_NOW}" tenstorrent-hugepages.service
-				sudo systemctl enable "${SYSTEMD_NOW}" 'dev-hugepages\x2d1G.mount'
+				# adding quotes around SYSTEMD_NOW means they won't be
+				# interpretted, which is exactly what we want them to be
+				# shellcheck disable=2086
+				sudo systemctl enable ${SYSTEMD_NOW} tenstorrent-hugepages.service
+				# adding quotes around SYSTEMD_NOW means they won't be
+				# interpretted, which is exactly what we want them to be
+				# shellcheck disable=2086
+				sudo systemctl enable ${SYSTEMD_NOW} 'dev-hugepages\x2d1G.mount'
 			fi
 			;;
 		"fedora"|"rhel"|"centos")
@@ -820,8 +826,14 @@ manual_install_hugepages() {
 			sudo dnf install -y "${TOOLS_FILENAME}"
 			if [[ "${SYSTEMD_NO}" != 0 ]]
 			then
-				sudo systemctl enable "${SYSTEMD_NOW}" tenstorrent-hugepages.service
-				sudo systemctl enable "${SYSTEMD_NOW}" 'dev-hugepages\x2d1G.mount'
+				# adding quotes around SYSTEMD_NOW means they won't be
+				# interpretted, which is exactly what we want them to be
+				# shellcheck disable=2086
+				sudo systemctl enable ${SYSTEMD_NOW} tenstorrent-hugepages.service
+				# adding quotes around SYSTEMD_NOW means they won't be
+				# interpretted, which is exactly what we want them to be
+				# shellcheck disable=2086
+				sudo systemctl enable ${SYSTEMD_NOW} 'dev-hugepages\x2d1G.mount'
 			fi
 			;;
 		*)
@@ -1095,7 +1107,10 @@ main() {
 			;;
 		"pipx")
 			log "Using pipx for isolated package installation"
-			pipx ensurepath "${PIPX_ENSUREPATH_EXTRAS}"
+			# adding quotes around PIPX_ENSUREPATH_EXTRAS means they won't be
+			# interpretted, which is exactly what we want them to be
+			# shellcheck disable=2086
+			pipx ensurepath ${PIPX_ENSUREPATH_EXTRAS}
 			# Enable the pipx path in this shell session
 			export PATH="${PATH}:${HOME}/.local/bin/"
 			INSTALLED_IN_VENV=1


### PR DESCRIPTION
95eaa4e5ef9b2b495aa09b47fe0f0dd4b4c34a36
or
https://github.com/tenstorrent/tt-installer/commit/95eaa4e5ef9b2b495aa09b47fe0f0dd4b4c34a36

adjusts some lints from shellcheck, except that it doesn't confirm how it's supposed to work, in this case with pipx and such it wraps things in "'s that should be interpretted and causes failures that aren't intended.

This reverts that, adds an appropriate shellcheck dodge and adds a rough explanation for 'why' that shellcheck dodge needs to be there.  This should resolve several issues I've seen and/or seen reported, particulalry with system pre-install scripting and using pipx

Noting for @silvanshade because of the original commit