### PR TITLE
Update SFPI download URL

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -889,7 +889,6 @@ manual_install_sfpi() {
 		curl -fsSLO "${SFPI_RELEASE_URL}/${SFPI_VERSION}/${SFPI_FILE}"
 	fi
 
-
 	verify_download "${SFPI_FILE}"
 
 	case "${SFPI_FILE_EXT}" in


### PR DESCRIPTION
Per https://github.com/tenstorrent/tt-metal/issues/30846 and https://github.com/tenstorrent/sfpi/releases/tag/7.5.0, we need to update the SFPI download URL.