### PR TITLE
Add --log-driver none to the tt-metalium and tt-metalium-models scripts

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -606,6 +606,7 @@ METALIUM_IMAGE="${METALIUM_IMAGE_URL}:${METALIUM_IMAGE_TAG}"
 
 podman run --rm -it \\
   --privileged \\
+  --log-driver none \\
   --volume=/dev/hugepages-1G:/dev/hugepages-1G \\
   --volume=\${HOME}:/home/user \\
   --device=/dev/tenstorrent:/dev/tenstorrent \\
@@ -678,6 +679,7 @@ METALIUM_IMAGE="${METALIUM_MODELS_IMAGE_URL}:${METALIUM_MODELS_IMAGE_TAG}"
 #  override the entrypoint. Why not just corral users into /bin/bash?
 podman run --rm -it \\
   --privileged \\
+  --log-driver none \\
   --volume=/dev/hugepages-1G:/dev/hugepages-1G \\
   --device=/dev/tenstorrent:/dev/tenstorrent \\
   --env=DISPLAY=\${DISPLAY} \\


### PR DESCRIPTION
By default(!) podman logs every console interaction (keypresses, not just output) to the system journal which is quite iffy from a security perspective for interactive containers. Scrutenising ours for example I found people's HuggingFace tokens etc. Adding --log-driver none to these wrappers stops the logging.

https://github.com/containers/podman/discussions/14743

This can also be disabled for all containers run by a user with:

```
[containers]
log_driver="none"
```

In `~/.config/containers/containers.conf`.