### PR TITLE
Use new firmware URL

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -1130,8 +1130,8 @@ main() {
 
 		# Create FW_FILE based on FW_VERSION
 		FW_FILE="fw_pack-${FW_VERSION}.fwbundle"
-		FW_RELEASE_URL="https://github.com/tenstorrent/tt-firmware/releases/download"
-		BACKUP_FW_RELEASE_URL="https://github.com/tenstorrent/tt-zephyr-platforms/releases/download"
+		FW_RELEASE_URL="https://github.com/tenstorrent/tt-system-firmware/releases/download"
+		BACKUP_FW_RELEASE_URL="https://github.com/tenstorrent/tt-firmware/releases/download"
 
 		# Download from GitHub releases
 		if ! curl -fsSLO "${FW_RELEASE_URL}/v${FW_VERSION}/${FW_FILE}"; then


### PR DESCRIPTION
Releases now live at https://github.com/tenstorrent/tt-system-firmware