### PR TITLE
Inline ttis.sh into install.sh at build time

### DIFF
--- a/.github/workflows/build-test-installer.yml
+++ b/.github/workflows/build-test-installer.yml
@@ -47,6 +47,12 @@ jobs:
             matejak/argbash \
             install.m4 -o install.sh
 
+      - name: Inline ttis.sh into install.sh
+        run: |
+          # The released install.sh must be self-contained so it runs via
+          # `bash -c "$(curl ... install.sh)"` with no second file to fetch.
+          scripts/inline-ttis.sh install.sh ttis.sh
+
       - name: Upload install.sh as artifact
         uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-install.sh: install.m4
+install.sh: install.m4 ttis.sh scripts/inline-ttis.sh
 	cp install.m4 install.sh.temp
 	sed -i "s|__INSTALLER_DEVELOPMENT_BUILD__|$(shell date +%Y.%m.%d-%H.%M.%S )-$(shell git log --format="%h" -n 1 )|g" install.sh.temp
 	argbash install.sh.temp -o install.sh
+	scripts/inline-ttis.sh install.sh ttis.sh
 
 GOLDEN_TAG := $(shell grep -oP '(?<=TTIS_GOLDEN_VERSIONS_TAG=")[^"]+' install.m4)
 GOLDEN_URL := https://github.com/tenstorrent/tt-sw-manifest/releases/download/$(GOLDEN_TAG)/golden.tar.gz

--- a/install.m4
+++ b/install.m4
@@ -426,6 +426,10 @@ get_python_choice() {
 			;;
 	esac
 
+	# PYTHON_ENV_LOCATION / PYTHON_ENV_PYTHON_VERSION are consumed by ttis_export,
+	# which is inlined into install.sh at build time, so shellcheck -x on install.m4
+	# can't see the use here.
+	# shellcheck disable=SC2034
 	case "${PYTHON_CHOICE}" in
 		"new-venv"|"active-venv") PYTHON_ENV_METHOD="venv";   PYTHON_ENV_LOCATION="${VIRTUAL_ENV:-}" ;;
 		"system-python")          PYTHON_ENV_METHOD="global"; PYTHON_ENV_LOCATION="" ;;
@@ -434,6 +438,7 @@ get_python_choice() {
 
 	# Record the venv interpreter version (python3 is the venv after activation)
 	# so it round-trips through ttis_export/import.
+	# shellcheck disable=SC2034
 	if [[ "${PYTHON_ENV_METHOD}" == "venv" ]]; then
 		PYTHON_ENV_PYTHON_VERSION="$(python3 -c 'import sys; print(f"{sys.version_info.major}.{sys.version_info.minor}")' 2>/dev/null || echo "")"
 	else

--- a/install.m4
+++ b/install.m4
@@ -126,15 +126,13 @@ NC='\033[0m' # No Color
 # matrix; the Golden Matrix CI workflow reads this value out of install.m4.
 readonly TTIS_GOLDEN_VERSIONS_TAG="v2026.06.26"
 
-# Source ttis.sh — provides TTIS_PACKAGE_MAP (used to build package_registry)
-# and the ttis_* functions used by --versions / --export-schema.
-_TTIS_PATH="$(dirname "${BASH_SOURCE[0]}")/ttis.sh"
-if [[ ! -f "${_TTIS_PATH}" ]]; then
-	echo "[ERROR] ttis.sh not found at ${_TTIS_PATH}" >&2
-	exit 1
-fi
-# shellcheck source=ttis.sh
-source "${_TTIS_PATH}"
+# ttis.sh is inlined here at build time (see scripts/inline-ttis.sh), replacing
+# the placeholder line below with the body of ttis.sh between its TTIS_INLINE
+# markers. This keeps the released install.sh a single self-contained file so it
+# runs via `bash -c "$(curl ... install.sh)"` with no second file to fetch.
+# ttis.sh provides TTIS_PACKAGE_MAP (used to build package_registry) and the
+# ttis_* functions used by --versions / --export-schema.
+# __TTIS_INLINE__
 
 # argbash workaround: close square brackets ]]]]]
 

--- a/scripts/inline-ttis.sh
+++ b/scripts/inline-ttis.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# inline-ttis.sh — concatenate ttis.sh into the generated install.sh.
+#
+# The released install.sh must be a single self-contained file so it can run via
+#   /bin/bash -c "$(curl -fsSL .../install.sh)"
+# with no second file to download. This script replaces the `# __TTIS_INLINE__`
+# placeholder line (emitted from install.m4) with the body of ttis.sh between its
+# `# >>> TTIS_INLINE_BEGIN <<<` / `# >>> TTIS_INLINE_END <<<` markers.
+#
+# Usage: scripts/inline-ttis.sh <install.sh> <ttis.sh>
+set -euo pipefail
+
+INSTALL_SH="${1:?Usage: inline-ttis.sh <install.sh> <ttis.sh>}"
+TTIS_SH="${2:?Usage: inline-ttis.sh <install.sh> <ttis.sh>}"
+
+readonly BEGIN_MARK='# >>> TTIS_INLINE_BEGIN <<<'
+readonly END_MARK='# >>> TTIS_INLINE_END <<<'
+readonly PLACEHOLDER='# __TTIS_INLINE__'
+
+for f in "${INSTALL_SH}" "${TTIS_SH}"; do
+	[[ -f "${f}" ]] || { echo "[ERROR] No such file: ${f}" >&2; exit 1; }
+done
+
+if ! grep -qxF "${PLACEHOLDER}" "${INSTALL_SH}"; then
+	echo "[ERROR] Placeholder '${PLACEHOLDER}' not found in ${INSTALL_SH}" >&2
+	exit 1
+fi
+
+# Extract the inlinable body of ttis.sh (between the markers, exclusive).
+body_file="$(mktemp)"
+out_file="$(mktemp)"
+trap 'rm -f "${body_file}" "${out_file}"' EXIT
+
+awk -v b="${BEGIN_MARK}" -v e="${END_MARK}" '
+	$0 == b { inb=1; next }
+	$0 == e { inb=0; next }
+	inb     { print }
+' "${TTIS_SH}" > "${body_file}"
+
+if [[ ! -s "${body_file}" ]]; then
+	echo "[ERROR] No content found between TTIS inline markers in ${TTIS_SH}" >&2
+	exit 1
+fi
+
+# Replace the placeholder line with the extracted body. getline reproduces the
+# body verbatim (backslashes, brackets, quotes) with no escaping concerns.
+awk -v ph="${PLACEHOLDER}" -v bf="${body_file}" '
+	$0 == ph {
+		print "# --- begin inlined ttis.sh (build-time, see scripts/inline-ttis.sh) ---"
+		while ((getline line < bf) > 0) print line
+		close(bf)
+		print "# --- end inlined ttis.sh ---"
+		next
+	}
+	{ print }
+' "${INSTALL_SH}" > "${out_file}"
+
+cat "${out_file}" > "${INSTALL_SH}"
+echo "[INFO] Inlined ttis.sh into ${INSTALL_SH}"

--- a/ttis.sh
+++ b/ttis.sh
@@ -21,6 +21,13 @@ readonly _TTIS_LOADED=1
 
 set -euo pipefail
 
+# >>> TTIS_INLINE_BEGIN <<<
+# Everything between the TTIS_INLINE markers is concatenated into the generated
+# install.sh at build time (see scripts/inline-ttis.sh) so the released installer
+# is a single self-contained file. Keep the re-source guard, `set`, and the CLI
+# entry point OUTSIDE the markers — install.sh provides its own and must not pick
+# up ttis.sh's standalone argument handling.
+
 # ── Schema version ─────────────────────────────────────────────────────────────
 readonly TTIS_SCHEMA_VERSION=1
 readonly -a TTIS_VALID_RUNTIMES=(podman docker none)
@@ -549,8 +556,10 @@ ttis_import_versions() {
 	_ttis_log "pinned versions from golden baseline: ${file_distro} ${file_distro_ver}, schema v${schema_ver}"
 }
 
+# >>> TTIS_INLINE_END <<<
+
 # ── CLI entry point ────────────────────────────────────────────────────────────
-if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
 	case "${1:-}" in
 		validate) ttis_validate "${2:?Usage: ttis.sh validate <file>}" ;;
 		*) echo "Usage: ttis.sh validate <file>" >&2; exit 1 ;;


### PR DESCRIPTION
The released install.sh sourced ttis.sh via a relative path derived from ${BASH_SOURCE[0]}. Under the documented remote form `bash -c "$(curl ... install.sh)"` the script is a command string, not a file, so BASH_SOURCE is empty and `set -u` aborts with "BASH_SOURCE[0]: unbound variable" before anything runs. Even guarded, there is no ttis.sh alongside a piped script to source.

Make the released install.sh self-contained by concatenating ttis.sh in at build time:

- ttis.sh: wrap the inlinable body in TTIS_INLINE_BEGIN/END markers (excluding the re-source guard, `set`, and standalone CLI entry point); harden the standalone guard to ${BASH_SOURCE[0]:-}
- install.m4: replace the `source ttis.sh` block with a `# __TTIS_INLINE__` placeholder (no BASH_SOURCE reference remains)
- scripts/inline-ttis.sh: substitute the marked ttis.sh body for the placeholder in the generated install.sh, after argbash so ttis's brackets never pass through m4
- Makefile / build-test-installer.yml: run the inline step after argbash

ttis.sh is still shipped as a separate release asset for the installer-golden-versions validate/replay workflows.