### PR TITLE
Switch the default container runtime to Docker

### DIFF
--- a/.github/workflows/test-debian-ubuntu.yml
+++ b/.github/workflows/test-debian-ubuntu.yml
@@ -58,13 +58,18 @@ jobs:
           su - testuser -c '
             cd /home/testuser/workspace
 
-            # Run installer with test configuration (skip hardware-dependent steps)
+            # Run installer with test configuration (skip hardware-dependent steps).
+            # Force podman: the default runtime is docker, but these bare
+            # containers have no systemd/daemon, so a docker daemon cannot start.
+            # Rootless podman is daemonless and works here. The docker default is
+            # validated on the systemd-backed N150 hardware runner instead.
             timeout 600 bash install.sh \
               --mode-non-interactive \
               --versions=${{ inputs.channel }} \
               --install-kmd \
               --no-install-hugepages \
               --update-firmware=off \
+              --install-container-runtime=podman \
               --install-metalium-container \
               --install-sfpi \
               --python-choice=new-venv \

--- a/.github/workflows/test-fedora.yml
+++ b/.github/workflows/test-fedora.yml
@@ -54,13 +54,18 @@ jobs:
           su - testuser -c '
             cd /home/testuser/workspace
 
-            # Run installer with test configuration (skip hardware-dependent steps)
+            # Run installer with test configuration (skip hardware-dependent steps).
+            # Force podman: the default runtime is docker, but these bare
+            # containers have no systemd/daemon, so a docker daemon cannot start.
+            # Rootless podman is daemonless and works here. The docker default is
+            # validated on the systemd-backed N150 hardware runner instead.
             timeout 300 bash install.sh \
               --mode-non-interactive \
               --versions=${{ inputs.channel }} \
               --install-kmd \
               --install-hugepages \
               --update-firmware=off \
+              --install-container-runtime=podman \
               --install-metalium-container \
               --install-sfpi \
               --python-choice=new-venv \

--- a/.github/workflows/test-hosted-n150.yml
+++ b/.github/workflows/test-hosted-n150.yml
@@ -23,7 +23,8 @@ jobs:
     - name: Prepare system
       run: |
         # The runners come with docker preinstalled but we want to
-        # simulate a completely blank system for our Podman install
+        # simulate a completely blank system so the installer performs a fresh
+        # container-runtime install (docker, the default) from scratch.
         sudo apt-get purge -y docker-ce docker-ce-cli containerd.io
 
     - name: Checkout code

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Install the tenstorrent software stack with one command.
 **WARNING:** Take care with this command! Always be careful running unknown code.
 
 ## Using tt-metalium
-In addition to our system-level tools, this script installs tt-metalium, Tenstorrent's framework for building and running AI models. Metalium is installed as a container using Podman (default) or Docker. You have two container options, both of which can be installed:
+In addition to our system-level tools, this script installs tt-metalium, Tenstorrent's framework for building and running AI models. Metalium is installed as a container using Docker (default) or Podman. You have two container options, both of which can be installed:
 - tt-metalium container: 1GB, appropriate for using TT-NN
 - tt-metalium Model Demos Container: 10GB, includes a full build of tt-metalium
 
@@ -32,7 +32,7 @@ tt-installer performs the following actions on your system:
    - System tools and HugePages configuration
    - Python packages (tt-flash, tt-smi, etc.)
 4. Updates your card's firmware using tt-flash
-5. Installs a container runtime (Podman by default, Docker optional)
+5. Installs a container runtime (Docker by default, Podman optional)
 6. Installs tt-metalium as a container and configures the wrapper script for convenient access
 7. Installs tt-studio and tt-inference-server, our user-friendly model runtime systems
 
@@ -63,9 +63,9 @@ To skip certain components:
 ./install.sh --no-install-kmd --no-install-hugepages
 ```
 
-To use Docker instead of Podman:
+To use Podman instead of Docker:
 ```bash
-./install.sh --install-container-runtime=docker
+./install.sh --install-container-runtime=podman
 ```
 
 To skip container runtime installation:

--- a/install.m4
+++ b/install.m4
@@ -15,7 +15,7 @@ exit 11 #)
 # ========================= Boolean Arguments =========================
 # ARG_OPTIONAL_BOOLEAN([install-kmd],,[Kernel-Mode-Driver installation],[on])
 # ARG_OPTIONAL_BOOLEAN([install-hugepages],,[Configure HugePages],[on])
-# ARG_OPTIONAL_SINGLE([install-container-runtime],,[Container runtime to install: podman, docker, no],[podman])
+# ARG_OPTIONAL_SINGLE([install-container-runtime],,[Container runtime to install: podman, docker, no],[docker])
 # ARG_OPTIONAL_BOOLEAN([install-metalium-container],,[Download and install Metalium container],[on])
 # ARG_OPTIONAL_BOOLEAN([install-forge-container],,[Download and install Forge container],[off])
 # ARG_OPTIONAL_BOOLEAN([install-tt-flash],,[Install tt-flash for updating device firmware],[on])
@@ -506,7 +506,8 @@ EOF
 
 	# Pull the image
 	log "Pulling the tt-metalium image (this may take a while)..."
-	docker pull "${_arg_metalium_image_url}:${_arg_metalium_image_tag}" || error "Failed to pull image"
+	# shellcheck disable=2086 # CONTAINER_PULL_PREFIX is empty or "sudo"; must word-split
+	${CONTAINER_PULL_PREFIX} docker pull "${_arg_metalium_image_url}:${_arg_metalium_image_tag}" || error "Failed to pull image"
 
 	log "Metalium installation completed"
 	return 0
@@ -577,7 +578,8 @@ EOF
 
 	# Pull the image
 	log "Pulling the tt-metalium-models image (this may take a while)..."
-	docker pull "${METALIUM_MODELS_IMAGE_URL}:${METALIUM_MODELS_IMAGE_TAG}" || error "Failed to pull image"
+	# shellcheck disable=2086 # CONTAINER_PULL_PREFIX is empty or "sudo"; must word-split
+	${CONTAINER_PULL_PREFIX} docker pull "${METALIUM_MODELS_IMAGE_URL}:${METALIUM_MODELS_IMAGE_TAG}" || error "Failed to pull image"
 
 	log "Metalium Models installation completed"
 	return 0
@@ -669,7 +671,8 @@ EOF
 
 	# Pull the image
 	log "Pulling the tt-forge image (this may take a while)..."
-	docker pull "${_arg_forge_image_url}:${_arg_forge_image_tag}" || error "Failed to pull image"
+	# shellcheck disable=2086 # CONTAINER_PULL_PREFIX is empty or "sudo"; must word-split
+	${CONTAINER_PULL_PREFIX} docker pull "${_arg_forge_image_url}:${_arg_forge_image_tag}" || error "Failed to pull image"
 
 	log "Forge installation completed"
 	return 0
@@ -1137,7 +1140,13 @@ main() {
 	get_python_choice
 	install_tt_repos
 
-	# Install container runtime if requested
+	# Install container runtime if requested.
+	# CONTAINER_PULL_PREFIX prefixes image pulls done during this run. Docker is
+	# rootful and, when freshly installed, the user's new "docker" group membership
+	# is not active in the current session, so same-session pulls must use sudo.
+	# Podman is rootless, so sudo would push images into root's storage where the
+	# user's wrapper scripts could not see them; leave the prefix empty there.
+	CONTAINER_PULL_PREFIX=""
 	case "${_arg_install_container_runtime}" in
 		"podman")
 			install_podman
@@ -1145,6 +1154,7 @@ main() {
 			;;
 		"docker")
 			install_docker
+			CONTAINER_PULL_PREFIX="sudo"
 			;;
 		"no")
 			log "Skipping container runtime installation"


### PR DESCRIPTION
Docker is the industry standard and several user-facing tools make assumptions about docker-compose nuances which we can't fix with Podman. Podman will remain available for users who just want to run containers and can take advantage of the lighter weight and rootless features.