### PR TITLE
Add composite CI action for verified-baseline installs

### DIFF
--- a/.github/workflows/build-test-installer.yml
+++ b/.github/workflows/build-test-installer.yml
@@ -139,6 +139,46 @@ jobs:
       artifact_name: install-script
       channel: rolling
 
+  # Dogfood the composite CI action against the freshly built install.sh, with no
+  # hardware: container mode skips KMD/HugePages/SFPI and firmware stays off.
+  test-action-container:
+    name: Test CI action (container mode)
+    needs: [build, validate-golden]
+    runs-on: ubuntu-22.04
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Download install.sh
+      uses: actions/download-artifact@v4
+      with:
+        name: install-script
+
+    - name: Install jq
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y jq
+
+    - name: Run tt-installer action (container mode)
+      id: tt
+      uses: ./
+      with:
+        channel: release
+        mode: container
+        install-sh-path: ${{ github.workspace }}/install.sh
+        export-schema-path: ${{ runner.temp }}/state.ttis
+        upload-artifact: "false"
+
+    - name: Validate exported schema
+      run: |
+        set -euo pipefail
+        schema="${{ steps.tt.outputs.schema-path }}"
+        test -f "${schema}" || { echo "::error::schema not written"; exit 1; }
+        echo "✓ schema written to ${schema}"
+        cat "${schema}"
+        bash ttis.sh validate "${schema}"
+        echo "✓ schema valid"
+
   test-template-syntax:
     needs: build
     runs-on: ubuntu-latest
@@ -243,7 +283,7 @@ jobs:
     runs-on: ubuntu-latest
     # Only run if the build workflow completed successfully AND it was triggered by a version tag
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [build, validate-golden, test-debian-ubuntu, test-fedora, test-hosted-n150, test-debian-ubuntu-rolling]
+    needs: [build, validate-golden, test-debian-ubuntu, test-fedora, test-hosted-n150, test-debian-ubuntu-rolling, test-action-container]
 
     permissions:
       contents: write

--- a/.github/workflows/test-hosted-n150.yml
+++ b/.github/workflows/test-hosted-n150.yml
@@ -35,22 +35,18 @@ jobs:
       with:
         name: ${{ inputs.artifact_name }}
 
-    - name: Run installer on hosted N150
-      run: |
-        # Run installer with all components enabled.
-        # Firmware update is explicitly disabled — never flash on the hosted N150.
-        timeout 1800 sudo bash install.sh \
-          --versions=${{ inputs.channel }} \
-          --update-firmware=off \
-          --mode-non-interactive \
-          --verbose \
-          --export-schema /tmp/tt-installer-state.ttis \
-          --reboot-option=never
-
-        echo "✓ Installer completed successfully on hosted N150"
-
-        # The installer ran as root; make the schema readable by the runner user
-        sudo chmod 644 /tmp/tt-installer-state.ttis
+    # Dogfood the composite action so the hosted-N150 path exercises the same
+    # code customers use. Firmware update stays off — never flash on this runner.
+    - name: Install Tenstorrent stack
+      id: tt
+      timeout-minutes: 30
+      uses: ./
+      with:
+        channel: ${{ inputs.channel }}
+        install-sh-path: ${{ github.workspace }}/install.sh
+        update-firmware: "off"
+        export-schema-path: /tmp/tt-installer-state.ttis
+        upload-artifact: "false"
 
     - name: Schema write/validate/read
       run: |

--- a/README.md
+++ b/README.md
@@ -121,9 +121,14 @@ things:
 - **Dev bisection** — install the verified baseline, upgrade *one* package, run
   your tests. If they break, the upgrade is the cause.
 
+Pin the action to a released installer version (the action runs the `install.sh`
+from that same release, so the action and installer stay in lockstep). Pick a
+version from the [releases page](https://github.com/tenstorrent/tt-installer/releases)
+or the Marketplace listing — the examples below use `v3.2.0`.
+
 ```yaml
 # Dev bisection: known-good baseline, then test your change
-- uses: tenstorrent/tt-installer@v1
+- uses: tenstorrent/tt-installer@v3.2.0
   with:
     channel: release          # verified-working version set
 - run: pip install --upgrade my-tt-package==1.2.3   # the change under test
@@ -135,7 +140,7 @@ or on a hardware-less runner via `mode: container`, which skips the parts that
 need a device (KMD, HugePages, SFPI, container runtime):
 
 ```yaml
-- uses: tenstorrent/tt-installer@v1
+- uses: tenstorrent/tt-installer@v3.2.0
   with:
     channel: release
     mode: container           # runs on a plain ubuntu runner, no TT card

--- a/README.md
+++ b/README.md
@@ -109,6 +109,64 @@ replay later and is not needed for a normal install.
 
 Note that the installer requires superuser (sudo) permisssions to install packages, add DKMS modules, and configure hugepages.
 
+## Using in CI
+
+tt-installer ships a composite GitHub Action that installs the stack at a
+verified-working version set in one step. Pin the `release` channel to get a
+known-good baseline, then run your own steps against it. This is handy for two
+things:
+
+- **Release gating** — install the verified baseline and run smoke tests to
+  confirm a single-package bump didn't break the customer experience.
+- **Dev bisection** — install the verified baseline, upgrade *one* package, run
+  your tests. If they break, the upgrade is the cause.
+
+```yaml
+# Dev bisection: known-good baseline, then test your change
+- uses: tenstorrent/tt-installer@v1
+  with:
+    channel: release          # verified-working version set
+- run: pip install --upgrade my-tt-package==1.2.3   # the change under test
+- run: pytest tests/          # if this breaks, it's your package
+```
+
+The action works on a runner with a Tenstorrent card (full install, the default)
+or on a hardware-less runner via `mode: container`, which skips the parts that
+need a device (KMD, HugePages, SFPI, container runtime):
+
+```yaml
+- uses: tenstorrent/tt-installer@v1
+  with:
+    channel: release
+    mode: container           # runs on a plain ubuntu runner, no TT card
+```
+
+The runner must allow passwordless `sudo` (the installer adds DKMS modules and
+configures HugePages). Firmware updates are **off by default** so CI never
+flashes a device.
+
+### Action inputs
+
+| Input | Default | Description |
+| ----- | ------- | ----------- |
+| `channel` | `release` | `--versions`: `release` (golden baseline), `rolling` (latest of everything), or a path to a `.ttis` file. |
+| `mode` | `hardware` | `hardware` (full install) or `container` (adds `--mode-container`). |
+| `update-firmware` | `off` | `--update-firmware`: `on`, `off`, or `force`. |
+| `container-runtime` | `docker` | `--install-container-runtime`: `docker`, `podman`, or `no`. Ignored when `mode: container`. |
+| `installer-version` | _(auto)_ | tt-installer release to fetch `install.sh` from. Defaults to the ref the action was called at (e.g. a `vX` tag), falling back to `latest`. |
+| `export-schema-path` | `${{ runner.temp }}/tt-installer-state.ttis` | Where the resulting `.ttis` state file is written. |
+| `extra-args` | _(empty)_ | Extra arguments appended verbatim, e.g. `--no-install-tt-topology`. |
+| `github-token` | `${{ github.token }}` | Passed to `--github-token` to avoid API rate limits. |
+| `upload-artifact` | `true` | Upload the exported `.ttis` as a workflow artifact. |
+
+### Action outputs
+
+| Output | Description |
+| ------ | ----------- |
+| `schema-path` | Absolute path to the exported `.ttis` state file. |
+| `installer-version` | The tt-installer release `install.sh` was sourced from. |
+| `channel` | The version channel that was used. |
+
 ## Distro Compatibility
 Our preferred OS is Ubuntu 22.04.5 LTS (Jammy Jellyfish). Other operating systems will not be prioritized for support or features.
 For more information, please see this compatibility matrix:

--- a/action.yml
+++ b/action.yml
@@ -1,0 +1,191 @@
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+
+name: "Install Tenstorrent Stack"
+description: >-
+  Install the Tenstorrent software stack in CI at a verified-working version set
+  (system packages, pip packages, firmware) via tt-installer. Pin to the 'release'
+  channel for a known-good baseline, then run your own upgrade/test steps.
+author: "Tenstorrent"
+
+branding:
+  icon: "cpu"
+  color: "gray-dark"
+
+inputs:
+  channel:
+    description: >-
+      Version channel passed to --versions: 'release' (pin to the golden,
+      verified-working version set), 'rolling' (latest of everything), or a path
+      to a .ttis state file.
+    required: false
+    default: "release"
+  mode:
+    description: >-
+      'hardware' for a runner with a Tenstorrent card (full install incl. KMD),
+      or 'container' for a hardware-less runner (adds --mode-container, which
+      skips KMD, HugePages, SFPI, and the container runtime).
+    required: false
+    default: "hardware"
+  update-firmware:
+    description: >-
+      Firmware update policy (--update-firmware): 'on', 'off', or 'force'.
+      Defaults to 'off' so CI never flashes a device.
+    required: false
+    default: "off"
+  container-runtime:
+    description: >-
+      Container runtime to install (--install-container-runtime): 'docker',
+      'podman', or 'no'. Ignored when mode=container (the installer forces 'no').
+    required: false
+    default: "docker"
+  installer-version:
+    description: >-
+      Which tt-installer release to fetch install.sh from. Leave empty to use the
+      ref this action was called with (e.g. a 'vX' release tag), falling back to
+      'latest' for branches/SHAs. Ignored when install-sh-path is set.
+    required: false
+    default: ""
+  install-sh-path:
+    description: >-
+      Escape hatch: path to a local install.sh to run instead of downloading one.
+      Used to dogfood the action against a freshly built, pre-release script.
+    required: false
+    default: ""
+  export-schema-path:
+    description: "Path the resulting .ttis state file is written to (--export-schema)."
+    required: false
+    default: "${{ runner.temp }}/tt-installer-state.ttis"
+  extra-args:
+    description: >-
+      Extra arguments appended verbatim to the install.sh invocation, e.g.
+      '--no-install-tt-topology --python-choice=system-python'.
+    required: false
+    default: ""
+  github-token:
+    description: "GitHub token passed to --github-token to avoid API rate limits."
+    required: false
+    default: ${{ github.token }}
+  upload-artifact:
+    description: "Upload the exported .ttis as a workflow artifact ('true'/'false')."
+    required: false
+    default: "true"
+
+outputs:
+  schema-path:
+    description: "Absolute path to the exported .ttis state file."
+    value: ${{ steps.install.outputs.schema-path }}
+  installer-version:
+    description: "The tt-installer release the install.sh was sourced from."
+    value: ${{ steps.fetch.outputs.installer-version }}
+  channel:
+    description: "The version channel that was used."
+    value: ${{ inputs.channel }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Resolve version and fetch install.sh
+      id: fetch
+      shell: bash
+      env:
+        INPUT_INSTALL_SH_PATH: ${{ inputs.install-sh-path }}
+        INPUT_INSTALLER_VERSION: ${{ inputs.installer-version }}
+        ACTION_REF: ${{ github.action_ref }}
+      run: |
+        set -euo pipefail
+
+        if [[ -n "${INPUT_INSTALL_SH_PATH}" ]]; then
+          if [[ ! -f "${INPUT_INSTALL_SH_PATH}" ]]; then
+            echo "::error::install-sh-path '${INPUT_INSTALL_SH_PATH}' does not exist"
+            exit 1
+          fi
+          echo "Using provided install.sh: ${INPUT_INSTALL_SH_PATH}"
+          echo "install-sh=${INPUT_INSTALL_SH_PATH}" >> "${GITHUB_OUTPUT}"
+          echo "installer-version=local:${INPUT_INSTALL_SH_PATH}" >> "${GITHUB_OUTPUT}"
+          exit 0
+        fi
+
+        ref="${INPUT_INSTALLER_VERSION}"
+        if [[ -z "${ref}" ]]; then
+          # Default to the ref this action was invoked at, so the installer and the
+          # action stay version-aligned. Branches/SHAs fall back to 'latest'.
+          case "${ACTION_REF}" in
+            v*) ref="${ACTION_REF}" ;;
+            *)  ref="latest" ;;
+          esac
+        fi
+
+        if [[ "${ref}" == "latest" ]]; then
+          url="https://github.com/tenstorrent/tt-installer/releases/latest/download/install.sh"
+        else
+          url="https://github.com/tenstorrent/tt-installer/releases/download/${ref}/install.sh"
+        fi
+
+        dest="${RUNNER_TEMP}/install.sh"
+        echo "Fetching install.sh (${ref}) from ${url}"
+        curl -fsSL "${url}" -o "${dest}"
+
+        echo "install-sh=${dest}" >> "${GITHUB_OUTPUT}"
+        echo "installer-version=${ref}" >> "${GITHUB_OUTPUT}"
+
+    - name: Run installer
+      id: install
+      shell: bash
+      env:
+        INSTALL_SH: ${{ steps.fetch.outputs.install-sh }}
+        INPUT_CHANNEL: ${{ inputs.channel }}
+        INPUT_MODE: ${{ inputs.mode }}
+        INPUT_UPDATE_FIRMWARE: ${{ inputs.update-firmware }}
+        INPUT_CONTAINER_RUNTIME: ${{ inputs.container-runtime }}
+        INPUT_EXPORT_SCHEMA_PATH: ${{ inputs.export-schema-path }}
+        INPUT_EXTRA_ARGS: ${{ inputs.extra-args }}
+        INPUT_GITHUB_TOKEN: ${{ inputs.github-token }}
+      run: |
+        set -euo pipefail
+
+        case "${INPUT_MODE}" in
+          hardware) mode_flag="" ;;
+          container) mode_flag="--mode-container" ;;
+          *) echo "::error::mode must be 'hardware' or 'container', got '${INPUT_MODE}'"; exit 1 ;;
+        esac
+
+        args=(
+          "--versions=${INPUT_CHANNEL}"
+          --mode-non-interactive
+          --reboot-option=never
+          "--update-firmware=${INPUT_UPDATE_FIRMWARE}"
+          "--install-container-runtime=${INPUT_CONTAINER_RUNTIME}"
+          "--github-token=${INPUT_GITHUB_TOKEN}"
+          --export-schema "${INPUT_EXPORT_SCHEMA_PATH}"
+          --verbose
+        )
+        if [[ -n "${mode_flag}" ]]; then
+          args+=("${mode_flag}")
+        fi
+        # shellcheck disable=SC2206
+        if [[ -n "${INPUT_EXTRA_ARGS}" ]]; then
+          extra=(${INPUT_EXTRA_ARGS})
+          args+=("${extra[@]}")
+        fi
+
+        echo "Running: sudo bash ${INSTALL_SH} ${args[*]}"
+        sudo bash "${INSTALL_SH}" "${args[@]}"
+
+        # The installer runs as root; make the schema readable by the runner user.
+        if [[ -f "${INPUT_EXPORT_SCHEMA_PATH}" ]]; then
+          sudo chmod 644 "${INPUT_EXPORT_SCHEMA_PATH}"
+        else
+          echo "::error::expected schema at '${INPUT_EXPORT_SCHEMA_PATH}' but it was not written"
+          exit 1
+        fi
+
+        echo "schema-path=${INPUT_EXPORT_SCHEMA_PATH}" >> "${GITHUB_OUTPUT}"
+
+    - name: Upload state file artifact
+      if: ${{ inputs.upload-artifact == 'true' }}
+      uses: actions/upload-artifact@v4
+      with:
+        name: tt-installer-state
+        path: ${{ steps.install.outputs.schema-path }}
+        if-no-files-found: error

--- a/install.m4
+++ b/install.m4
@@ -24,6 +24,7 @@ exit 11 #)
 # ARG_OPTIONAL_BOOLEAN([install-sfpi],,[Install SFPI],[on])
 # ARG_OPTIONAL_BOOLEAN([install-inference-server],,[Install tt-inference-server],[on])
 # ARG_OPTIONAL_BOOLEAN([install-studio],,[Install tt-studio],[on])
+# ARG_OPTIONAL_BOOLEAN([pull-container-images],,[Pre-pull container images (Metalium/Forge) during install; if off (default), the wrapper scripts pull on first run instead],[off])
 
 # =========================  Metalium Container Arguments =========================
 # ARG_OPTIONAL_SINGLE([metalium-image-url],,[Container image URL to pull/run],[ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-amd64])
@@ -505,9 +506,13 @@ EOF
 	fi
 
 	# Pull the image
-	log "Pulling the tt-metalium image (this may take a while)..."
-	# shellcheck disable=2086 # CONTAINER_PULL_PREFIX is empty or "sudo"; must word-split
-	${CONTAINER_PULL_PREFIX} docker pull "${_arg_metalium_image_url}:${_arg_metalium_image_tag}" || error "Failed to pull image"
+	if [[ "${_arg_pull_container_images}" == "on" ]]; then
+		log "Pulling the tt-metalium image (this may take a while)..."
+		# shellcheck disable=2086 # CONTAINER_PULL_PREFIX is empty or "sudo"; must word-split
+		${CONTAINER_PULL_PREFIX} docker pull "${_arg_metalium_image_url}:${_arg_metalium_image_tag}" || error "Failed to pull image"
+	else
+		log "Skipping tt-metalium image pull (--no-pull-container-images); the ${_arg_metalium_container_script_name} wrapper will pull it on first run"
+	fi
 
 	log "Metalium installation completed"
 	return 0
@@ -577,9 +582,13 @@ EOF
 	fi
 
 	# Pull the image
-	log "Pulling the tt-metalium-models image (this may take a while)..."
-	# shellcheck disable=2086 # CONTAINER_PULL_PREFIX is empty or "sudo"; must word-split
-	${CONTAINER_PULL_PREFIX} docker pull "${METALIUM_MODELS_IMAGE_URL}:${METALIUM_MODELS_IMAGE_TAG}" || error "Failed to pull image"
+	if [[ "${_arg_pull_container_images}" == "on" ]]; then
+		log "Pulling the tt-metalium-models image (this may take a while)..."
+		# shellcheck disable=2086 # CONTAINER_PULL_PREFIX is empty or "sudo"; must word-split
+		${CONTAINER_PULL_PREFIX} docker pull "${METALIUM_MODELS_IMAGE_URL}:${METALIUM_MODELS_IMAGE_TAG}" || error "Failed to pull image"
+	else
+		log "Skipping tt-metalium-models image pull (--no-pull-container-images); the ${METALIUM_MODELS_SCRIPT_NAME} wrapper will pull it on first run"
+	fi
 
 	log "Metalium Models installation completed"
 	return 0
@@ -670,9 +679,13 @@ EOF
 	fi
 
 	# Pull the image
-	log "Pulling the tt-forge image (this may take a while)..."
-	# shellcheck disable=2086 # CONTAINER_PULL_PREFIX is empty or "sudo"; must word-split
-	${CONTAINER_PULL_PREFIX} docker pull "${_arg_forge_image_url}:${_arg_forge_image_tag}" || error "Failed to pull image"
+	if [[ "${_arg_pull_container_images}" == "on" ]]; then
+		log "Pulling the tt-forge image (this may take a while)..."
+		# shellcheck disable=2086 # CONTAINER_PULL_PREFIX is empty or "sudo"; must word-split
+		${CONTAINER_PULL_PREFIX} docker pull "${_arg_forge_image_url}:${_arg_forge_image_tag}" || error "Failed to pull image"
+	else
+		log "Skipping tt-forge image pull (--no-pull-container-images); the ${_arg_forge_container_script_name} wrapper will pull it on first run"
+	fi
 
 	log "Forge installation completed"
 	return 0


### PR DESCRIPTION
## What

Wraps `install.sh` as a Marketplace-listable **composite GitHub Action** so any TT repo can get to a verified-working version set in one `uses:` step, then run its own upgrade/test steps. Targets two use cases:

- **Release gating** — install the verified baseline (`--versions=release`) and run smoke tests to confirm a single-package bump didn't break the customer experience.
- **Dev bisection** — install the baseline, upgrade *one* package, run tests; if they break, the upgrade is the cause.

```yaml
- uses: tenstorrent/tt-installer@v3.3.0
  with:
    channel: release          # verified-working version set
- run: pip install --upgrade my-tt-package==1.2.3
- run: pytest tests/
```

## Changes

- **`action.yml`** (repo root) — fetches `install.sh` from the release matching the action ref (or `latest`), runs it non-interactively with reboot disabled, exports the `.ttis`, chmods it readable, sets outputs (`schema-path`, `installer-version`, `channel`), optionally uploads the schema artifact. Inputs cover `channel`, `mode` (hardware/container), `update-firmware` (off by default — CI never flashes), `container-runtime`, `installer-version`, `install-sh-path` (dogfood escape hatch), `export-schema-path`, `extra-args` (verbatim passthrough), `github-token`, `upload-artifact`.
- **`README.md`** — new "Using in CI" section with examples and input/output tables.
- **`build-test-installer.yml`** — new `test-action-container` job dogfoods the action in container mode (no hardware) against the freshly built `install.sh`; gated into `create-release`.
- **`test-hosted-n150.yml`** — refactored to `uses: ./` so the hosted-N150 path and customer usage share one code path.

The action is a thin shim over flags that already exist in `install.m4`, so there's nothing new to maintain on the installer side.

## Notes / follow-ups

- README examples reference `tenstorrent/tt-installer@v1`, which doesn't exist yet. Publishing to the Marketplace needs a `v1` major tag plus the "publish this Action to the Marketplace" checkbox on a release.
- Both YAML files parse; embedded action scripts are shellcheck-clean.

## Test plan

- [ ] `test-action-container` job goes green (container-mode install + schema validation, no hardware)
- [ ] `test-hosted-n150` job goes green via the refactored action path

🤖 Generated with [Claude Code](https://claude.com/claude-code)