### PR TITLE
Prefer UBUNTU_CODENAME on Ubuntu derivatives (e.g. Linux Mint)

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -831,8 +831,13 @@ install_tt_repos () {
 	case "${DISTRO_ID}" in
 		"ubuntu")
 			# Add the apt listing
-			# shellcheck disable=2002
-			echo "deb [signed-by=/etc/apt/keyrings/tt-pkg-key.asc] https://ppa.tenstorrent.com/ubuntu/ $( cat /etc/os-release | grep "^VERSION_CODENAME=" | sed 's/^VERSION_CODENAME=//' ) main" | sudo tee /etc/apt/sources.list.d/tenstorrent.list > /dev/null
+			# Prefer UBUNTU_CODENAME (set to the upstream codename on Ubuntu
+			# derivatives such as Linux Mint) and fall back to VERSION_CODENAME.
+			codename=$( . /etc/os-release && printf '%s' "${UBUNTU_CODENAME:-${VERSION_CODENAME:-}}" )
+			if [[ -z "${codename}" ]]; then
+				error_exit "Could not determine apt repository codename from /etc/os-release (need UBUNTU_CODENAME or VERSION_CODENAME)"
+			fi
+			echo "deb [signed-by=/etc/apt/keyrings/tt-pkg-key.asc] https://ppa.tenstorrent.com/ubuntu/ ${codename} main" | sudo tee /etc/apt/sources.list.d/tenstorrent.list > /dev/null
 
 			# Setup the keyring
 			sudo mkdir -p /etc/apt/keyrings; sudo chmod 755 /etc/apt/keyrings


### PR DESCRIPTION
## Summary
- On Ubuntu derivatives such as Linux Mint, `VERSION_CODENAME` carries the
  derivative codename (e.g. `wilma`, `xia`) instead of the upstream Ubuntu
  codename (`noble`). The PPA only publishes per-Ubuntu-release pockets, so
  `https://ppa.tenstorrent.com/ubuntu/<derivative-codename>` 404s and
  `apt-get update` aborts the installer.
- Prefer `UBUNTU_CODENAME` (set to the upstream codename on derivatives) and
  fall back to `VERSION_CODENAME` for vanilla Ubuntu. Fail loudly when neither
  is set, instead of silently producing a broken `sources.list` entry.

## Tested
- Ubuntu 24.04 (vanilla) → `VERSION_CODENAME=noble` (unchanged)
- Linux Mint 22.x (`wilma` / `xia` / `zara`) → `UBUNTU_CODENAME=noble`

## Validated downstream
This exact fix is carried as a patch in
[tt-metal-community-distro-matrix](https://github.com/tetsuh/tt-metal-community-distro-matrix),
which runs the installer across many distros in CI. With the patch applied,
the installer succeeds on Linux Mint 21.3 and 22.1–22.3, where the unpatched
installer 404s on `apt-get update`
([CI run](https://github.com/tetsuh/tt-metal-community-distro-matrix/actions/runs/29258581555)).

Merging this upstream would let that project drop its
[Linux Mint installer patch](https://github.com/tetsuh/tt-metal-community-distro-matrix/tree/main/patches/linuxmint/installer)
once it tracks a release containing this change.

Companion to #101 (which added `ID_LIKE`-based distro detection for the same
derivatives).
