### PR TITLE
Handle dpkg lock contention, version downgrades, and existing container runtimes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,14 @@ that ships with each release. Control this with `--versions`:
 a `.ttis` file. It is a developer/CI feature for capturing a configuration to
 replay later and is not needed for a normal install.
 
+Pinned channels can move you *backwards*: if you previously installed with
+`--versions=rolling` (or manually installed newer packages) and later re-run
+with `--versions=release` or a `.ttis` file, the pinned versions may be older
+than what is on your system. The installer handles this by passing
+`--allow-downgrades` to apt, and on dnf-based distros by routing packages whose
+pinned version is below the installed one through `dnf downgrade` (dnf's
+`install` command cannot downgrade a package).
+
 Note that the installer requires superuser (sudo) permisssions to install packages, add DKMS modules, and configure hugepages.
 
 ## Using in CI

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ tt-installer performs the following actions on your system:
    - System tools and HugePages configuration
    - Python packages (tt-flash, tt-smi, etc.)
 4. Updates your card's firmware using tt-flash
-5. Installs a container runtime (Docker by default, Podman optional)
+5. Installs a container runtime if one is not already present (Docker by default, Podman optional)
 6. Installs tt-metalium as a container and configures the wrapper script for convenient access
 7. Installs tt-studio and tt-inference-server, our user-friendly model runtime systems
 
@@ -63,16 +63,23 @@ To skip certain components:
 ./install.sh --no-install-kmd --no-install-hugepages
 ```
 
-To use Podman instead of Docker:
+### Container runtime selection
+
+By default (`--install-container-runtime=auto`) the installer checks whether
+Docker or Podman is already installed. If one is found, it is left untouched (a
+warning is printed and installation is skipped, avoiding a pointless reinstall
+and possible package conflicts). If neither is found, Docker is installed.
+
+To force a specific runtime regardless of what is installed:
 ```bash
-./install.sh --install-container-runtime=podman
+./install.sh --install-container-runtime=docker   # or podman
 ```
 
-To skip container runtime installation:
+To skip container runtime installation entirely:
 ```bash
-./install.sh --install-container-runtime=no
+./install.sh --install-container-runtime=none
 ```
-If you have already installed Docker or Podman, this option will leave them untouched.
+(`no` is still accepted as a deprecated alias for `none`.)
 
 To specify versions:
 ```bash
@@ -165,7 +172,7 @@ flashes a device.
 | `channel` | `release` | `--versions`: `release` (golden baseline), `rolling` (latest of everything), or a path to a `.ttis` file. |
 | `mode` | `hardware` | `hardware` (full install) or `container` (adds `--mode-container`). |
 | `update-firmware` | `off` | `--update-firmware`: `on`, `off`, or `force`. |
-| `container-runtime` | `docker` | `--install-container-runtime`: `docker`, `podman`, or `no`. Ignored when `mode: container`. |
+| `container-runtime` | `auto` | `--install-container-runtime`: `auto` (install Docker unless a runtime is already present), `docker`, `podman`, or `none`. Ignored when `mode: container`. |
 | `installer-version` | _(auto)_ | tt-installer release to fetch `install.sh` from. Defaults to the ref the action was called at (e.g. a `vX` tag), falling back to `latest`. |
 | `export-schema-path` | `${{ runner.temp }}/tt-installer-state.ttis` | Where the resulting `.ttis` state file is written. |
 | `extra-args` | _(empty)_ | Extra arguments appended verbatim, e.g. `--no-install-tt-topology`. |

--- a/action.yml
+++ b/action.yml
@@ -33,10 +33,11 @@ inputs:
     default: "off"
   container-runtime:
     description: >-
-      Container runtime to install (--install-container-runtime): 'docker',
-      'podman', or 'no'. Ignored when mode=container (the installer forces 'no').
+      Container runtime to install (--install-container-runtime): 'auto'
+      (install Docker unless a runtime is already present), 'docker', 'podman',
+      or 'none'. Ignored when mode=container (the installer forces 'none').
     required: false
-    default: "docker"
+    default: "auto"
   installer-version:
     description: >-
       Which tt-installer release to fetch install.sh from. Leave empty to use the

--- a/install.m4
+++ b/install.m4
@@ -168,6 +168,28 @@ check_has_sudo_perms() {
 	fi
 }
 
+# Seconds apt-get waits for the dpkg lock before giving up. Ubuntu's
+# unattended-upgrades or the apt daily timer can hold the lock when we run.
+APT_LOCK_TIMEOUT=120
+
+# Wrapper for all apt-get invocations:
+# - Waits up to APT_LOCK_TIMEOUT seconds for the dpkg lock instead of aborting
+#   immediately, and explains what to do if the wait still times out.
+apt_get() {
+	local apt_status=0
+	local apt_log="${WORKDIR}/apt-last-run.log"
+	local apt_opts=("-o" "DPkg::Lock::Timeout=${APT_LOCK_TIMEOUT}")
+	# 2>&1 keeps apt's errors in the tee'd log so we can detect a lock timeout
+	sudo DEBIAN_FRONTEND=noninteractive apt-get "${apt_opts[@]}" "$@" 2>&1 | tee "${apt_log}" || apt_status=$?
+	if [[ "${apt_status}" -ne 0 ]] && grep -Eq "Could not get lock|Unable to acquire the dpkg" "${apt_log}"; then
+		error "apt-get could not acquire the dpkg lock after waiting ${APT_LOCK_TIMEOUT} seconds."
+		error "Another package manager process is holding it — usually Ubuntu's unattended-upgrades or the apt daily timer."
+		error "See what holds the lock with: sudo fuser -v /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock"
+		error "Wait for it to finish (or stop it with 'sudo systemctl stop unattended-upgrades'), then re-run this installer."
+	fi
+	return "${apt_status}"
+}
+
 detect_distro() {
 	# shellcheck disable=SC1091 # Always present
 	if [[ -f /etc/os-release ]]; then
@@ -840,7 +862,7 @@ install_tt_repos () {
 			# Download the key
 			sudo wget -O /etc/apt/keyrings/tt-pkg-key.asc https://ppa.tenstorrent.com/tt-pkg-key.asc
 
-			sudo apt-get update
+			apt_get update
 			;;
 		"debian")
 			# Add the apt listing
@@ -853,7 +875,7 @@ install_tt_repos () {
 			# Download the key
 			sudo wget -O /etc/apt/keyrings/tt-pkg-key.asc https://ppa.tenstorrent.com/tt-pkg-key.asc
 
-			sudo apt-get update
+			apt_get update
 			;;
 		"fedora")
 			sudo bash -c 'cat > /etc/yum.repos.d/tenstorrent.repo << EOF
@@ -971,7 +993,7 @@ install_podman() {
 	log "Installing Podman and podman-docker shim"
 	case "${PKG_MANAGER}" in
 		"apt-get")
-			sudo apt-get install -y podman podman-docker
+			apt_get install -y podman podman-docker
 			;;
 		"dnf")
 			sudo dnf install -y podman podman-docker podman-compose
@@ -1108,13 +1130,13 @@ main() {
 	log "Installing base packages"
 	case "${DISTRO_ID}" in
 		"ubuntu")
-			sudo apt-get update
-			sudo DEBIAN_FRONTEND=noninteractive apt-get install -y git python3-pip dkms cargo rustc pipx jq protobuf-compiler wget
+			apt_get update
+			apt_get install -y git python3-pip dkms cargo rustc pipx jq protobuf-compiler wget
 			;;
 		"debian")
 			# On Debian, packaged cargo and rustc are very old. Users must install them another way.
-			sudo apt-get update
-			sudo apt-get install -y git python3-pip dkms pipx jq protobuf-compiler wget
+			apt_get update
+			apt_get install -y git python3-pip dkms pipx jq protobuf-compiler wget
 			;;
 		"fedora")
 			sudo dnf install -y git python3-pip python3-devel dkms cargo rust pipx jq protobuf-compiler wget
@@ -1234,7 +1256,7 @@ main() {
 	if [[ ${#system_packages[@]} -gt 0 ]]; then
 		echo "Installing system packages: ${system_packages[*]}"
 		if [[ "${PKG_MANAGER}" = "apt-get" ]]; then
-			sudo apt-get install -y "${system_packages[@]}"
+			apt_get install -y "${system_packages[@]}"
 		elif [[ "${PKG_MANAGER}" = "dnf" ]]; then
 			sudo dnf install -y "${system_packages[@]}"
 		fi

--- a/install.m4
+++ b/install.m4
@@ -175,10 +175,15 @@ APT_LOCK_TIMEOUT=120
 # Wrapper for all apt-get invocations:
 # - Waits up to APT_LOCK_TIMEOUT seconds for the dpkg lock instead of aborting
 #   immediately, and explains what to do if the wait still times out.
+# - Allows downgrades on install, needed when pinned versions (the 'release'
+#   channel or an imported .ttis file) are older than what is installed.
 apt_get() {
 	local apt_status=0
 	local apt_log="${WORKDIR}/apt-last-run.log"
 	local apt_opts=("-o" "DPkg::Lock::Timeout=${APT_LOCK_TIMEOUT}")
+	if [[ "${1:-}" == "install" ]]; then
+		apt_opts+=("--allow-downgrades")
+	fi
 	# 2>&1 keeps apt's errors in the tee'd log so we can detect a lock timeout
 	sudo DEBIAN_FRONTEND=noninteractive apt-get "${apt_opts[@]}" "$@" 2>&1 | tee "${apt_log}" || apt_status=$?
 	if [[ "${apt_status}" -ne 0 ]] && grep -Eq "Could not get lock|Unable to acquire the dpkg" "${apt_log}"; then
@@ -1217,6 +1222,7 @@ main() {
 
 	# 2. Parse the registry to obtain lists of packages
 	declare -a system_packages=()
+	declare -a system_downgrade_packages=()
 	declare -a python_packages=()
 
 	for key in "${!package_registry[@]}"; do
@@ -1235,7 +1241,19 @@ main() {
 					if [[ "${PKG_MANAGER}" = "apt-get" ]]; then
 						system_packages+=("${pkg_name}=${version}")
 					elif [[ "${PKG_MANAGER}" = "dnf" ]]; then
-						system_packages+=("${pkg_name}-${version}")
+						# dnf "install" refuses to downgrade a package. If the
+						# pinned version (e.g. the 'release' channel after using
+						# 'rolling', or an imported .ttis file) is older than the
+						# installed one, route it through "dnf downgrade" instead.
+						installed_version=""
+						if rpm -q "${pkg_name}" &> /dev/null; then
+							installed_version="$(rpm -q --qf '%{VERSION}-%{RELEASE}' "${pkg_name}")"
+						fi
+						if [[ -n "${installed_version}" && "${version}" != "${installed_version}" && "$(printf '%s\n%s\n' "${version}" "${installed_version}" | sort -V | head -n 1)" == "${version}" ]]; then
+							system_downgrade_packages+=("${pkg_name}-${version}")
+						else
+							system_packages+=("${pkg_name}-${version}")
+						fi
 					else
 						system_packages+=("${pkg_name}")  # fallback to no version
 					fi
@@ -1260,6 +1278,13 @@ main() {
 		elif [[ "${PKG_MANAGER}" = "dnf" ]]; then
 			sudo dnf install -y "${system_packages[@]}"
 		fi
+	fi
+
+	# Downgrade system packages pinned below the installed version. Only used
+	# with dnf; apt handles downgrades in the install above via --allow-downgrades.
+	if [[ ${#system_downgrade_packages[@]} -gt 0 ]]; then
+		echo "Downgrading system packages: ${system_downgrade_packages[*]}"
+		sudo dnf downgrade -y "${system_downgrade_packages[@]}"
 	fi
 
 	# Install Python packages

--- a/install.m4
+++ b/install.m4
@@ -15,7 +15,7 @@ exit 11 #)
 # ========================= Boolean Arguments =========================
 # ARG_OPTIONAL_BOOLEAN([install-kmd],,[Kernel-Mode-Driver installation],[on])
 # ARG_OPTIONAL_BOOLEAN([install-hugepages],,[Configure HugePages],[on])
-# ARG_OPTIONAL_SINGLE([install-container-runtime],,[Container runtime to install: podman, docker, no],[docker])
+# ARG_OPTIONAL_SINGLE([install-container-runtime],,[Container runtime to install: auto (install Docker unless a runtime is already present), podman, docker, none],[auto])
 # ARG_OPTIONAL_BOOLEAN([install-metalium-container],,[Download and install Metalium container],[on])
 # ARG_OPTIONAL_BOOLEAN([install-forge-container],,[Download and install Forge container],[off])
 # ARG_OPTIONAL_BOOLEAN([install-tt-flash],,[Install tt-flash for updating device firmware],[on])
@@ -83,12 +83,18 @@ LOGO=$(cat << "EOF"
 EOF
 )
 
+# Backward compatibility: --install-container-runtime once used "no"; it is
+# now "none" to match the syntax of other arguments.
+if [[ "${_arg_install_container_runtime}" = "no" ]]; then
+	_arg_install_container_runtime="none"
+fi
+
 # If container mode is enabled, disable KMD, HugePages, and SFPI
 # shellcheck disable=SC2154
 if [[ "${_arg_mode_container}" = "on" ]]; then
 	_arg_install_kmd="off"
 	_arg_install_hugepages="off" # Both KMD and HugePages must live on the host kernel
-	_arg_install_container_runtime="no" # No container runtime in container
+	_arg_install_container_runtime="none" # No container runtime in container
 	_arg_install_sfpi="off"
 	_arg_reboot_option="never" # Do not reboot
 fi
@@ -629,7 +635,7 @@ get_metalium_container_choice() {
 		return
 	fi
 	# Only ask if a container runtime is installed or will be installed
-	if [[ "${_arg_install_container_runtime}" != "no" ]] || check_container_runtime_installed; then
+	if [[ "${_arg_install_container_runtime}" != "none" ]] || check_container_runtime_installed; then
 		# Interactive mode - allow override
 		log "Would you like to install the TT-Metalium slim container?"
 		log "This container is appropriate if you only need to use TT-NN"
@@ -644,7 +650,7 @@ get_metalium_container_choice() {
 		warn "Container runtime is not and will not be installed, skipping Metalium container installation"
 	fi
 	# Only ask if a container runtime is installed or will be installed
-	if [[ "${_arg_install_container_runtime}" != "no" ]] || check_container_runtime_installed; then
+	if [[ "${_arg_install_container_runtime}" != "none" ]] || check_container_runtime_installed; then
 		# Interactive mode - allow override
 		log "Would you like to install the TT-Metalium Model Demos container?"
 		log "This container is best for users who need more TT-Metalium functionality, such as running prebuilt models, but it's large (8GB)"
@@ -725,7 +731,7 @@ get_forge_container_choice() {
 		return
 	fi
 	# Only ask if a container runtime is installed or will be installed
-	if [[ "${_arg_install_container_runtime}" != "no" ]] || check_container_runtime_installed; then
+	if [[ "${_arg_install_container_runtime}" != "none" ]] || check_container_runtime_installed; then
 		# Interactive mode - allow override
 		log "Would you like to install the TT-Forge slim container?"
 		if confirm "Install Forge"; then
@@ -1092,7 +1098,7 @@ main() {
 	if [[ "${_arg_install_hugepages}" = "off" ]]; then
 		warn "HugePages setup will be skipped"
 	fi
-	if [[ "${_arg_install_container_runtime}" = "no" ]]; then
+	if [[ "${_arg_install_container_runtime}" = "none" ]]; then
 		warn "Container runtime installation will be skipped"
 	fi
 	if [[ "${_arg_install_metalium_container}" = "off" ]]; then
@@ -1169,7 +1175,7 @@ main() {
 
 	# Disable container runtime install if both Metalium and Forge containers are disabled
 	if [[ "${_arg_install_metalium_container}" = "off" ]] && [[ "${_arg_install_metalium_models_container}" = "off" ]] && [[ "${_arg_install_forge_container}" = "off" ]]; then
-		_arg_install_container_runtime="no"
+		_arg_install_container_runtime="none"
 	fi
 
 	# Get tt-inference-server installation choice
@@ -1188,6 +1194,31 @@ main() {
 	# user's wrapper scripts could not see them; leave the prefix empty there.
 	CONTAINER_PULL_PREFIX=""
 	case "${_arg_install_container_runtime}" in
+		"auto")
+			if command -v docker &> /dev/null || command -v podman &> /dev/null; then
+				warn "A container runtime is already installed; skipping container runtime installation to avoid reinstalling it or creating package conflicts."
+				# Record which runtime we found so it round-trips through
+				# --export-schema (podman may provide the docker CLI via the
+				# podman-docker shim), and use sudo for same-session pulls only
+				# if the docker CLI needs it.
+				if command -v docker &> /dev/null && ! docker --version 2> /dev/null | grep -qi podman; then
+					_arg_install_container_runtime="docker"
+					if ! docker info &> /dev/null; then
+						CONTAINER_PULL_PREFIX="sudo"
+					fi
+				else
+					_arg_install_container_runtime="podman"
+					if ! command -v docker &> /dev/null; then
+						warn "Podman is installed but the 'docker' CLI shim is not. The tt-metalium/tt-forge wrapper scripts invoke 'docker'; install the podman-docker package if they fail."
+					fi
+				fi
+			else
+				log "No container runtime found, installing Docker"
+				install_docker
+				_arg_install_container_runtime="docker"
+				CONTAINER_PULL_PREFIX="sudo"
+			fi
+			;;
 		"podman")
 			install_podman
 			setup_rootless_podman
@@ -1196,11 +1227,11 @@ main() {
 			install_docker
 			CONTAINER_PULL_PREFIX="sudo"
 			;;
-		"no")
+		"none")
 			log "Skipping container runtime installation"
 			;;
 		*)
-			error_exit "Invalid container runtime option: ${_arg_install_container_runtime}. Must be 'podman', 'docker', or 'no'"
+			error_exit "Invalid container runtime option: ${_arg_install_container_runtime}. Must be 'auto', 'podman', 'docker', or 'none'"
 			;;
 	esac
 
@@ -1353,7 +1384,7 @@ main() {
 	if [[ "${_arg_install_metalium_container}" = "off" ]]; then
 		warn "Skipping Metalium container installation"
 	else
-		if [[ "${_arg_install_container_runtime}" = "no" ]] && ! check_container_runtime_installed; then
+		if [[ "${_arg_install_container_runtime}" = "none" ]] && ! check_container_runtime_installed; then
 			warn "No container runtime is installed. Cannot install Metalium container."
 		else
 			install_metalium_container
@@ -1362,7 +1393,7 @@ main() {
 
 	# Install Metalium Models container if requested
 	if [[ "${_arg_install_metalium_models_container}" = "on" ]]; then
-		if [[ "${_arg_install_container_runtime}" = "no" ]] && ! check_container_runtime_installed; then
+		if [[ "${_arg_install_container_runtime}" = "none" ]] && ! check_container_runtime_installed; then
 			warn "No container runtime is installed. Cannot install Metalium Models."
 		else
 			install_metalium_models_container
@@ -1377,7 +1408,7 @@ main() {
 	if [[ "${_arg_install_forge_container}" = "off" ]]; then
 		warn "Skipping Forge container installation"
 	else
-		if [[ "${_arg_install_container_runtime}" = "no" ]] && ! check_container_runtime_installed; then
+		if [[ "${_arg_install_container_runtime}" = "none" ]] && ! check_container_runtime_installed; then
 			warn "No container runtime is installed. Cannot install Forge container."
 		else
 			install_forge_container

--- a/ttis.sh
+++ b/ttis.sh
@@ -288,7 +288,7 @@ ttis_export() {
 	esac
 
 	local runtime
-	case "${_arg_install_container_runtime:-no}" in
+	case "${_arg_install_container_runtime:-none}" in
 		"podman") runtime="podman" ;;
 		"docker") runtime="docker" ;;
 		*)        runtime="none"   ;;
@@ -479,7 +479,7 @@ ttis_import() {
 		case "${val}" in
 			"podman") _arg_install_container_runtime="podman" ;;
 			"docker") _arg_install_container_runtime="docker" ;;
-			"none")   _arg_install_container_runtime="no"     ;;
+			"none")   _arg_install_container_runtime="none"   ;;
 		esac
 	fi
 


### PR DESCRIPTION
Fixes three issues seen in baseline install runs:

1. **dpkg lock race (exit 100)** — all apt calls now go through an `apt_get` wrapper that passes `-o DPkg::Lock::Timeout=120`, so the installer waits for unattended-upgrades / the apt daily timer instead of aborting. If the wait still times out, it prints what holds the lock and how to resolve it.
2. **Downgrades on pinned channels** — apt installs pass `--allow-downgrades`; on dnf, packages pinned below the installed version are routed through `dnf downgrade` (dnf `install` cannot downgrade a named package on dnf4 or dnf5). Needed when re-running with `--versions=release` or a `.ttis` file after `rolling`.
3. **Docker reinstall when already present** — new `--install-container-runtime=auto` (now the default, including in the CI action): skips installation with a warning when Docker or Podman is already installed, avoiding get-docker.sh's 20s reinstall pause and package conflicts; installs Docker otherwise. Also renames the `no` value to `none` to match other arguments (`no` remains a deprecated alias).

Verified: shellcheck clean at each commit, all golden `.ttis` files validate, wrapper behavior (flag injection, lock detection, exit-status propagation) and dnf downgrade routing covered by stubbed smoke tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)