### PR TITLE
feat: install rustup from the distro repos where it is packaged

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -243,6 +243,55 @@ detect_distro() {
 	fi
 }
 
+# True when version $1 is greater than or equal to $2. Uses sort -V so that
+# 24.04 orders correctly against 24.4, and 13 against 9.
+version_ge() {
+	[[ -n "${1}" ]] && [[ "$(printf '%s\n%s\n' "${2}" "${1}" | sort -V | head -n1)" == "${2}" ]]
+}
+
+# rustup is packaged from Debian 13 (trixie) and Ubuntu 24.04 (noble) onwards.
+# Earlier suites have no rustup package at all, so callers must fall back.
+# Requires detect_distro to have run. Suites without a VERSION_ID (Debian
+# testing/unstable) report false and take the fallback path.
+has_packaged_rustup() {
+	case "${DISTRO_ID}" in
+		"debian") version_ge "${VERSION_ID:-}" "13" ;;
+		"ubuntu") version_ge "${VERSION_ID:-}" "24.04" ;;
+		*) return 1 ;;
+	esac
+}
+
+# Install a Rust toolchain on apt-based distros.
+#
+# Where rustup is packaged we prefer it: it tracks current stable, whereas the
+# distro rustc/cargo lag and on Debian are too old to build our dependencies.
+# The rustup package owns /usr/bin/cargo and /usr/bin/rustc as shims, so it
+# replaces the cargo and rustc packages rather than sitting alongside them —
+# both cannot own those paths.
+install_rust() {
+	if has_packaged_rustup; then
+		log "Installing Rust via the packaged rustup"
+		apt_get install -y rustup
+		# The shims need a toolchain behind them. Without this cargo and rustc
+		# are on PATH but refuse to run. Deliberately not run through sudo:
+		# rustup is per-user, and the toolchain belongs to whoever invoked the
+		# installer rather than to root.
+		rustup default stable
+		return
+	fi
+
+	case "${DISTRO_ID}" in
+		"ubuntu")
+			# No rustup before 24.04; the distro toolchain is current enough here.
+			apt_get install -y cargo rustc
+			;;
+		"debian")
+			warn "rustc and cargo cannot be automatically installed on Debian ${VERSION_ID:-(unknown version)}; its packaged toolchain is too old."
+			warn "Ensure recent versions are installed before continuing. If you are unsure how, use rustup: https://rustup.rs/"
+			;;
+	esac
+}
+
 # Fetch the golden .ttis schema for this distro from the pinned
 # tt-sw-manifest release. The release publishes one asset per
 # distro/version named "<distro_id>-<version_id>.ttis", so we download that file
@@ -1171,14 +1220,10 @@ main() {
 
 	log "Installing base packages"
 	case "${DISTRO_ID}" in
-		"ubuntu")
-			apt_get update
-			apt_get install -y git python3-pip dkms cargo rustc pipx jq protobuf-compiler
-			;;
-		"debian")
-			# On Debian, packaged cargo and rustc are very old. Users must install them another way.
+		"ubuntu"|"debian")
 			apt_get update
 			apt_get install -y git python3-pip dkms pipx jq protobuf-compiler
+			install_rust
 			;;
 		"fedora")
 			sudo dnf install -y git python3-pip python3-devel dkms cargo rust pipx jq protobuf-compiler
@@ -1192,11 +1237,6 @@ main() {
 			exit 1
 			;;
 	esac
-
-	if [[ "${DISTRO_ID}" = "debian" ]]; then
-		warn "rustc and cargo cannot be automatically installed on Debian. Ensure the latest versions are installed before continuing."
-		warn "If you are unsure how to do this, use rustup: https://rustup.rs/"
-	fi
 
 	# Get Metalium container installation choice
 	get_metalium_container_choice

--- a/tests/test-rustup-detection.sh
+++ b/tests/test-rustup-detection.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# Tests for rustup availability detection (issue #111).
+#
+# rustup is packaged from Debian 13 (trixie) and Ubuntu 24.04 (noble) onwards,
+# and not at all before that, so the installer has to branch on the suite
+# version rather than the distro alone. This exercises that branch without
+# needing a container per suite.
+#
+# The functions are extracted from install.m4 rather than copied, so the test
+# fails if the implementation moves or changes shape.
+#
+# Usage: tests/test-rustup-detection.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SOURCE_FILE="${SCRIPT_DIR}/../install.m4"
+
+if [[ ! -f "${SOURCE_FILE}" ]]; then
+	echo "cannot find install.m4 at ${SOURCE_FILE}" >&2
+	exit 1
+fi
+
+# Pull the two functions under test out of install.m4 and into this shell.
+extract_function() {
+	awk -v name="$1" '
+		$0 ~ "^" name "\\(\\) \\{" { collecting = 1 }
+		collecting { print }
+		collecting && /^\}$/ { exit }
+	' "${SOURCE_FILE}"
+}
+
+for fn in version_ge has_packaged_rustup; do
+	body="$(extract_function "${fn}")"
+	if [[ -z "${body}" ]]; then
+		echo "FAIL: could not extract ${fn}() from install.m4" >&2
+		exit 1
+	fi
+	eval "${body}"
+done
+
+PASS=0
+FAIL=0
+
+check() {
+	local desc="$1" expected="$2" actual="$3"
+	if [[ "${expected}" == "${actual}" ]]; then
+		PASS=$((PASS + 1))
+	else
+		FAIL=$((FAIL + 1))
+		echo "FAIL: ${desc} — expected ${expected}, got ${actual}"
+	fi
+}
+
+# ---- version_ge ----------------------------------------------------------
+version_case() {
+	local a="$1" b="$2" expected="$3"
+	local actual="no"
+	version_ge "${a}" "${b}" && actual="yes"
+	check "version_ge '${a}' '${b}'" "${expected}" "${actual}"
+}
+
+version_case "13"    "13"    yes   # equal
+version_case "14"    "13"    yes
+version_case "12"    "13"    no
+version_case "9"     "13"    no    # lexical compare would get this wrong
+version_case "24.04" "24.04" yes
+version_case "24.10" "24.04" yes   # lexical compare would get this wrong
+version_case "22.04" "24.04" no
+version_case "25.04" "24.04" yes
+version_case "100"   "99"    yes   # lexical compare would get this wrong
+version_case ""      "13"    no    # missing VERSION_ID must not pass
+
+# ---- has_packaged_rustup -------------------------------------------------
+rustup_case() {
+	local distro="$1" version="$2" expected="$3"
+	local actual="no"
+	DISTRO_ID="${distro}" VERSION_ID="${version}"
+	has_packaged_rustup && actual="yes"
+	check "has_packaged_rustup ${distro} ${version:-<unset>}" "${expected}" "${actual}"
+}
+
+# Verified against the package archives:
+#   packages.debian.org/trixie/rustup   1.27.1-3   present
+#   packages.debian.org/bookworm/rustup            absent
+#   packages.ubuntu.com/noble/rustup    1.26.0     present (universe)
+#   packages.ubuntu.com/jammy/rustup               absent
+rustup_case debian 13      yes
+rustup_case debian 12      no
+rustup_case debian 11      no
+rustup_case debian 14      yes
+rustup_case debian ""      no    # testing/unstable carry no VERSION_ID
+rustup_case ubuntu 24.04   yes
+rustup_case ubuntu 22.04   no
+rustup_case ubuntu 20.04   no
+rustup_case ubuntu 24.10   yes
+rustup_case ubuntu 26.04   yes
+rustup_case ubuntu ""      no
+rustup_case fedora 42      no    # not apt-based; falls to the dnf branch
+rustup_case rhel   9       no
+
+echo
+echo "${PASS} passed, ${FAIL} failed"
+[[ "${FAIL}" -eq 0 ]]


### PR DESCRIPTION
Fixes #111

rustup entered the official repositories in Debian 13 (trixie) and Ubuntu 24.04 (noble), so the toolchain no longer has to be left to the user there.

Both apt branches now call `install_rust()`, which uses the packaged rustup where the suite has it and keeps the existing behaviour where it does not:

| Suite | Before | After |
|---|---|---|
| Debian ≥ 13 | nothing installed, user warned | `rustup` + `rustup default stable` |
| Debian < 13 | nothing installed, user warned | unchanged |
| Ubuntu ≥ 24.04 | distro `cargo` + `rustc` | `rustup` + `rustup default stable` |
| Ubuntu < 24.04 | distro `cargo` + `rustc` | unchanged |

## Two things the issue doesn't mention, which shaped this

**The rustup package owns `/usr/bin/cargo` and `/usr/bin/rustc`.** They are rustup shims, so the package replaces `cargo` and `rustc` rather than sitting alongside them — both cannot own those paths. That is why the Ubuntu branch swaps the packages rather than adding one.

**It ships no toolchain.** Without `rustup default stable` the shims are on PATH but refuse to run, so the installer would appear to succeed and leave the machine with no compiler. That call deliberately does not go through `sudo`: rustup is per-user, and the toolchain belongs to whoever invoked the installer, not to root.

Verified against the archives rather than assumed:

| | rustup |
|---|---|
| trixie | 1.27.1-3 |
| noble | 1.26.0 (universe) |
| bookworm | not available |
| jammy | not available |

## Version detection

`version_ge` compares with `sort -V` rather than as strings, so `9` does not sort above `13` and `24.10` does not sort below `24.04`. A suite with no `VERSION_ID` — Debian testing/unstable — takes the fallback path rather than assuming rustup is present.

## Tests

New file: `tests/test-rustup-detection.sh`, 23 assertions, covering both distros either side of the cutoff plus the non-apt distros.

It extracts `version_ge` and `has_packaged_rustup` from `install.m4` rather than copying them, so it fails if the implementation moves or changes shape.

I sanity-checked that the tests can actually fail: swapping `sort -V` for a plain `sort` breaks `9 >= 13` and `100 >= 99`, and the suite catches both.

## What I could not verify locally

I have no container runtime and no `m4`/`autoconf` on this machine, so I could not run argbash to generate `install.sh` or reproduce the `test-debian-ubuntu.yml` matrix. What I did check: the three new functions parse under `bash -n`, and the version logic is covered by the test above. CI covers `ubuntu:22.04`, `ubuntu:24.04` and `debian:13`, which is exactly the set of branches this touches — so it should be well exercised there.

## One decision worth your call

On an Ubuntu 24.04 machine that already has `cargo`/`rustc` installed, `apt-get install -y rustup` will remove them in order to take ownership of those paths. That is correct, but it is a package removal on an existing system and you may prefer it announced, guarded, or skipped when a recent toolchain is already present. Happy to change it either way.
