### PR TITLE
feat: add --dry-run mode to preview installation plan

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ To skip certain components:
 ./install.sh --no-install-kmd --no-install-hugepages
 ```
 
+To preview the installation plan without making any system changes:
+```bash
+./install.sh --dry-run
+```
+`--dry-run` resolves the same platform details and package selections as a real
+install (including the active [version channel](#version-channels)), then prints
+the plan — detected distribution, architecture and kernel, the system and Python
+packages that would be installed, and the actions that would be taken for
+drivers, HugePages, the container runtime, and firmware — and exits without
+touching the system.
+
 ### Container runtime selection
 
 By default (`--install-container-runtime=auto`) the installer checks whether

--- a/install.m4
+++ b/install.m4
@@ -1050,30 +1050,90 @@ install_docker() {
 
 # Main installation script
 handle_dry_run() {
-    if [[ "${_arg_dry_run}" = "on" ]]; then
-        echo ""
-        echo "=== DRY RUN MODE ==="
-        echo "No system changes will be made."
-        echo ""
-        echo "Platform: ${DISTRO_ID:-unknown} ${DISTRO_VERSION_ID:-unknown} $(uname -m)"
-        echo ""
-        echo "Planned actions:"
-        echo "  [PKG] Install base packages"
-        [[ "${_arg_install_kmd}" = "on" ]] && echo "  [KMD] Install Kernel-Mode-Driver"
-        [[ "${_arg_install_hugepages}" = "on" ]] && echo "  [HUGEPAGES] Configure HugePages"
-        [[ "${_arg_install_container_runtime}" != "none" ]] && echo "  [CONTAINER] Install ${_arg_install_container_runtime}"
-        echo "  [PYTHON] Install Python packages"
-        [[ "${_arg_update_firmware}" != "off" ]] && echo "  [FIRMWARE] Update firmware"
-        echo ""
-        echo "===================="
-        exit 0
-    fi
+	[[ "${_arg_dry_run}" = "on" ]] || return 0
+
+	echo ""
+	echo "=== DRY RUN: installation plan (no system changes will be made) ==="
+	echo ""
+	echo "Platform:"
+	echo "  Distribution:    ${DISTRO_ID:-unknown} ${VERSION_ID:-unknown}"
+	echo "  Architecture:    $(uname -m)"
+	echo "  Kernel:          $(uname -r)"
+	echo "  Package manager: ${PKG_MANAGER:-unknown}"
+	echo "  Version channel: ${_arg_versions}"
+	echo ""
+
+	# Build the package registry exactly as the real install does, so the plan
+	# reflects the concrete package/version selections for this run (including
+	# any pins resolved from the selected version channel or an imported .ttis).
+	declare -A package_registry=()
+	for _ttis_entry in "${TTIS_PACKAGE_MAP[@]}"; do
+		IFS='|' read -r _ttis_pkg _ttis_type _ttis_ivar _ttis_vvar <<< "${_ttis_entry}"
+		package_registry["${_ttis_pkg}"]="${_ttis_pkg}|${!_ttis_ivar}|${!_ttis_vvar}|${_ttis_type}"
+	done
+	for _ttis_entry in "${TTIS_IMPORTED_PACKAGES[@]+"${TTIS_IMPORTED_PACKAGES[@]}"}"; do
+		IFS='|' read -r _ttis_pkg _ttis_flag _ttis_ver _ttis_type <<< "${_ttis_entry}"
+		package_registry["${_ttis_pkg}"]="${_ttis_pkg}|${_ttis_flag}|${_ttis_ver}|${_ttis_type}"
+	done
+	unset _ttis_entry _ttis_pkg _ttis_flag _ttis_ver _ttis_type _ttis_ivar _ttis_vvar
+
+	declare -a system_packages=()
+	declare -a python_packages=()
+	for key in "${!package_registry[@]}"; do
+		IFS='|' read -r pkg_name install_flag version pkg_type <<< "${package_registry[${key}]}"
+		[[ "${install_flag}" != "on" ]] && continue
+		case "${pkg_type}" in
+			system)
+				if [[ -z "${version}" ]]; then
+					system_packages+=("${pkg_name}")
+				elif [[ "${PKG_MANAGER}" = "apt-get" ]]; then
+					system_packages+=("${pkg_name}=${version}")
+				else
+					system_packages+=("${pkg_name}-${version}")
+				fi
+				;;
+			python)
+				if [[ -z "${version}" ]]; then
+					python_packages+=("${pkg_name}")
+				else
+					python_packages+=("${pkg_name}==${version}")
+				fi
+				;;
+		esac
+	done
+
+	echo "Planned actions:"
+	echo ""
+	echo "  System packages:"
+	if [[ ${#system_packages[@]} -gt 0 ]]; then
+		printf '    - %s\n' "${system_packages[@]}"
+	else
+		echo "    (none)"
+	fi
+	echo ""
+	echo "  Python packages:"
+	if [[ ${#python_packages[@]} -gt 0 ]]; then
+		printf '    - %s\n' "${python_packages[@]}"
+	else
+		echo "    (none)"
+	fi
+	echo ""
+	echo "  Kernel-Mode Driver: $([[ "${_arg_install_kmd}" = "on" ]] && echo install || echo skip)"
+	echo "  HugePages:          $([[ "${_arg_install_hugepages}" = "on" ]] && echo configure || echo skip)"
+	echo "  Container runtime:  ${_arg_install_container_runtime}"
+	echo "  Metalium container: $([[ "${_arg_install_metalium_container}" = "on" ]] && echo install || echo skip)"
+	echo "  Forge container:    $([[ "${_arg_install_forge_container}" = "on" ]] && echo install || echo skip)"
+	echo "  Firmware update:    ${_arg_update_firmware}"
+	echo "  Python strategy:    ${_arg_python_choice} (uv: ${_arg_use_uv})"
+	echo "  Privileges:         sudo required"
+	echo "  Reboot policy:      ${_arg_reboot_option}"
+	echo ""
+	echo "=============================================================="
+	exit 0
 }
 
 
 main() {
-	handle_dry_run
-
 	echo -e "${LOGO}"
 	echo # newline
 	INSTALLER_VERSION="__INSTALLER_DEVELOPMENT_BUILD__" # Set to semver at release time by GitHub Actions
@@ -1137,6 +1197,8 @@ main() {
 		log "Component versions given on the command line take precedence over channel pins"
 	fi
 	unset _ver_var user_versions
+
+	handle_dry_run
 
 	maybe_enable_default_mode
 	log "Starting installation"

--- a/install.m4
+++ b/install.m4
@@ -67,6 +67,7 @@ exit 11 #)
 # ARG_OPTIONAL_BOOLEAN([mode-container],,[Enable container mode (skips KMD, HugePages, and SFPI, never reboots)],[off])
 # ARG_OPTIONAL_BOOLEAN([mode-non-interactive],,[Enable non-interactive mode (no user prompts)],[off])
 # ARG_OPTIONAL_BOOLEAN([verbose],,[Enable verbose output for debugging])
+# ARG_OPTIONAL_BOOLEAN([dry-run],,[Preview installation plan without modifying the system],[off])
 
 # ARGBASH_GO
 
@@ -1048,7 +1049,31 @@ install_docker() {
 }
 
 # Main installation script
+handle_dry_run() {
+    if [[ "${_arg_dry_run}" = "on" ]]; then
+        echo ""
+        echo "=== DRY RUN MODE ==="
+        echo "No system changes will be made."
+        echo ""
+        echo "Platform: ${DISTRO_ID:-unknown} ${DISTRO_VERSION_ID:-unknown} $(uname -m)"
+        echo ""
+        echo "Planned actions:"
+        echo "  [PKG] Install base packages"
+        [[ "${_arg_install_kmd}" = "on" ]] && echo "  [KMD] Install Kernel-Mode-Driver"
+        [[ "${_arg_install_hugepages}" = "on" ]] && echo "  [HUGEPAGES] Configure HugePages"
+        [[ "${_arg_install_container_runtime}" != "none" ]] && echo "  [CONTAINER] Install ${_arg_install_container_runtime}"
+        echo "  [PYTHON] Install Python packages"
+        [[ "${_arg_update_firmware}" != "off" ]] && echo "  [FIRMWARE] Update firmware"
+        echo ""
+        echo "===================="
+        exit 0
+    fi
+}
+
+
 main() {
+	handle_dry_run
+
 	echo -e "${LOGO}"
 	echo # newline
 	INSTALLER_VERSION="__INSTALLER_DEVELOPMENT_BUILD__" # Set to semver at release time by GitHub Actions

--- a/tests/test-dry-run.sh
+++ b/tests/test-dry-run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# Smoke test for --dry-run mode. Runs the built install.sh in dry-run mode and
+# asserts that the printed plan contains the platform details and selected
+# packages required by issue #140, without making any system changes.
+#
+# Usage: tests/test-dry-run.sh [path-to-install.sh]   (default: ./install.sh)
+
+set -euo pipefail
+
+INSTALL_SH="${1:-./install.sh}"
+
+if [[ ! -f "${INSTALL_SH}" ]]; then
+    echo "ERROR: ${INSTALL_SH} not found. Build it first (make install.sh)." >&2
+    exit 2
+fi
+
+OUT="$(mktemp)"
+trap 'rm -f "${OUT}"' EXIT
+
+# --dry-run must print the plan and exit 0 without modifying the system.
+bash "${INSTALL_SH}" --dry-run > "${OUT}" 2>&1
+rc=$?
+if [[ ${rc} -ne 0 ]]; then
+    echo "ERROR: --dry-run exited with status ${rc}" >&2
+    cat "${OUT}" >&2
+    exit 1
+fi
+
+fail() {
+    echo "ERROR: missing expected output: $1" >&2
+    cat "${OUT}" >&2
+    exit 1
+}
+
+grep -q "Distribution:" "${OUT}" || fail "Distribution line"
+grep -q "Architecture:" "${OUT}" || fail "Architecture line"
+grep -q "Kernel:" "${OUT}" || fail "Kernel line"
+grep -q "System packages:" "${OUT}" || fail "System packages section"
+grep -q "Python packages:" "${OUT}" || fail "Python packages section"
+grep -q "Kernel-Mode Driver:" "${OUT}" || fail "Kernel-Mode Driver line"
+grep -q "Container runtime:" "${OUT}" || fail "Container runtime line"
+grep -q "Firmware update:" "${OUT}" || fail "Firmware update line"
+
+echo "OK: --dry-run smoke test passed"


### PR DESCRIPTION
## Summary

Closes #140 — adds a `--dry-run` mode that builds and prints the installation plan without modifying the system.

The plan is produced after distro detection and version-channel resolution, so it reflects the same decisions a real install would make:

- **Platform**: detected distribution + version, architecture, kernel, package manager, and the active version channel (`release`/`rolling`/`.ttis`).
- **System packages**: the concrete list resolved from `TTIS_PACKAGE_MAP` (e.g. `tenstorrent-dkms`, `tenstorrent-tools`, `sfpi`), with pinned versions when the channel provides them.
- **Python packages**: `tt-smi`, `tt-flash`, etc., with versions.
- **Actions**: KMD install, HugePages config, container runtime, Metalium/Forge containers, firmware update, Python strategy (venv/uv), and reboot policy.

`--dry-run` exits cleanly before any prompt, sudo check, repo setup, or package install — nothing on the system is touched.

## Changes
- `install.m4`: rewrote `handle_dry_run` to resolve the real package lists and moved the invocation after distro/version resolution so output is accurate.
- `tests/test-dry-run.sh`: smoke test that runs `--dry-run` and asserts the required fields are present.
- `README.md`: documented `--dry-run`.

## Testing
```
bash install.sh --dry-run
```
(or `tests/test-dry-run.sh [path-to-install.sh]`)