### PR TITLE
install: refuse --kmd-version < 2.9.0 on RHEL/CentOS

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -1074,6 +1074,20 @@ main() {
 	# Detect distro early so PKG_MANAGER is set before ttis_import needs it.
 	detect_distro
 
+	# tenstorrent-dkms < 2.9.0 does not build on RHEL 9.4+ kernels: those
+	# kernels backport the one-argument class_create() and the removal of
+	# pci_enable/disable_pcie_error_reporting() while LINUX_VERSION_CODE still
+	# reports 5.14, so tt-kmd's version guards select the pre-6.x API path and
+	# the DKMS build fails (issue #93). tt-kmd 2.9.0 added TT_RHEL_RELEASE_GE
+	# guards for this; refuse older pins on RHEL/CentOS up front instead of
+	# letting dkms fail deep inside the install.
+	if [[ "${_arg_install_kmd}" != "off" && -n "${_arg_kmd_version}" ]] \
+		&& { [[ "${DISTRO_ID}" = "rhel" ]] || [[ "${DISTRO_ID}" = "centos" ]]; } \
+		&& [[ "${_arg_kmd_version}" != "2.9.0" \
+			&& "$(printf '%s\n2.9.0\n' "${_arg_kmd_version}" | sort -V | head -n 1)" = "${_arg_kmd_version}" ]]; then
+		error_exit "--kmd-version ${_arg_kmd_version} cannot be installed on ${DISTRO_ID}: tenstorrent-dkms < 2.9.0 does not build on RHEL 9.4+ kernels (issue #93). Use --kmd-version 2.9.0 or newer."
+	fi
+
 	# Version arguments given on the command line take precedence over versions
 	# pinned by the 'release' channel or imported from a .ttis file: capture
 	# them before the import and re-apply them afterwards.


### PR DESCRIPTION
## What

The installer now exits with an error when `--kmd-version` pins tenstorrent-dkms < 2.9.0 on RHEL/CentOS (including derivatives resolved via `ID_LIKE`), before any network fetch or package operation. Fedora is not affected (its kernels report true 6.x version codes, where the existing tt-kmd guards work).

## Why

RHEL 9.4+ backported the single-arg `class_create` and removed the `pci_*_pcie_error_reporting` stubs while `LINUX_VERSION_CODE` stays 5.14, so tt-kmd's version-code guards pick the legacy path and the DKMS build fails exactly as in #93. tenstorrent-dkms 2.9.0 added the `TT_RHEL_RELEASE_GE(9,4)` guards (tt-kmd 03b3338), so < 2.9.0 pins cannot build on RHEL 9.4+.

## Evidence

- `tt-installer-93-first-probe.log` — ttkmd-2.4.1 @ de2e855 compiles clean against 6.8.0-136 headers (`tenstorrent.ko` linked, `EXIT=0`): confirms the failure is RHEL-backport-specific, not a general 2.4.1 build break.
- `tt-installer-93-verify.log` — fresh-tree verification of this commit: rhel + 2.5.0 → guard fires, exit 1 before any package op; rocky ID_LIKE + 2.4.1 → guard; rhel + 2.9.0 → no guard, aborts safely at the sudo check with no dnf; ubuntu 24.04 + 2.5.0 → no guard, no apt; generated `install.sh` passes `bash -n`.

Refs #93