### PR TITLE
Honor --metalium-image-tag in the models-container wrapper (#119)

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -564,7 +564,7 @@ install_metalium_models_container() {
 	log "Installing Metalium Models Container via OCI container runtime"
 	local METALIUM_MODELS_SCRIPT_DIR="${HOME}/.local/bin"
 	local METALIUM_MODELS_SCRIPT_NAME="tt-metalium-models"
-	local METALIUM_MODELS_IMAGE_TAG="latest-rc"
+	local METALIUM_MODELS_IMAGE_TAG="${_arg_metalium_image_tag}"
 	local METALIUM_MODELS_IMAGE_URL="ghcr.io/tenstorrent/tt-metal/tt-metalium-ubuntu-22.04-release-models-amd64"
 
 	# Create wrapper script directory


### PR DESCRIPTION
`install_metalium_models_container()` hardcoded `METALIUM_MODELS_IMAGE_TAG="latest-rc"`, so the wrapper created by `--install-metalium-models-container` always pinned `latest-rc` and silently ignored `--metalium-image-tag`. The tag now reads `${_arg_metalium_image_tag}`, exactly like `install_metalium_container()` does; with no flag the default stays `latest-rc` (from the arg default), and the models image URL is unchanged — a one-line diff.

Verification (host-only): built `install.sh` via the CI argbash path and ran the generated installer in throwaway, unprivileged `ubuntu:24.04` containers (`--mode-non-interactive`, `--install-container-runtime none`, `--no-pull-container-images`; no images pulled). Run A passes `--metalium-image-tag v0.60.0`; run B omits the flag.

- `verify-ttinst119-pre.log` (pristine main): `CHECK A1-models-tag: FAIL` — the models wrapper embedded `latest-rc` despite `--metalium-image-tag v0.60.0`, while the regular metalium wrapper embedded `v0.60.0` in that same run (`CHECK A2-regular-tag: PASS`); installer rc=0 in both runs. Final line: `VERDICT: FAIL`.
- `verify-ttinst119-post.log` (this branch @ 8584cf2): `CHECK A1-models-tag: PASS` — the models wrapper embeds `v0.60.0`; `CHECK A2-regular-tag: PASS` — the control wrapper embeds `v0.60.0` in the same run; `CHECK B-default-latest-rc: PASS` — the no-flag run still embeds `latest-rc`; installer rc=0 in both runs. Final line: `VERDICT: PASS` (flag honored by the models wrapper; default stays `latest-rc`).

Closes #119