### PR TITLE
Add option to run tt-update-tensix-disable-count on firmware before install

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,23 @@ pinned version is below the installed one through `dnf downgrade` (dnf's
 
 Note that the installer requires superuser (sudo) permisssions to install packages, add DKMS modules, and configure hugepages.
 
+### Tensix disable count (Blackhole p150)
+
+Firmware v19.5.0+ disables 20 Tensix cores on Blackhole p150 boards by default.
+To keep all cores enabled, the downloaded firmware bundle can be patched with
+[tt-update-tensix-disable-count](https://pypi.org/project/tt-update-tensix-disable-count/)
+before it is flashed (the tool must already be installed and on `PATH`:
+`pip install tt-update-tensix-disable-count`):
+
+```bash
+./install.sh --patch-tensix-disable-count --tensix-disable-count=0
+```
+
+`--tensix-disable-count` defaults to `0` (all cores enabled). The patch is
+applied once to the downloaded bundle, for the p150 board images (`P150A-1`,
+`P150B-1`, `P150C-1`), before flashing; it requires `--update-firmware` to not
+be `off`.
+
 ## Using in CI
 
 tt-installer ships a composite GitHub Action that installs the stack at a

--- a/install.m4
+++ b/install.m4
@@ -45,6 +45,8 @@ exit 11 #)
 # ARG_OPTIONAL_SINGLE([python-version],,[Python version for a new venv (e.g. 3.12); requires --use-uv, which provisions it via uv],[3.12])
 # ARG_OPTIONAL_SINGLE([reboot-option],,[Reboot policy after install: ask, never, always],[ask])
 # ARG_OPTIONAL_SINGLE([update-firmware],,[Update TT device firmware: on, off, force],[force])
+# ARG_OPTIONAL_BOOLEAN([patch-tensix-disable-count],,[Run tt-update-tensix-disable-count on the downloaded firmware bundle before flashing (Blackhole p150 only)],[off])
+# ARG_OPTIONAL_SINGLE([tensix-disable-count],,[Tensix disable count to write into the firmware bundle],[0])
 # ARG_OPTIONAL_SINGLE([github-token],,[Optional GitHub API auth token],[])
 
 # ========================= Version Arguments =========================
@@ -1157,6 +1159,9 @@ main() {
 	if [[ "${_arg_update_firmware}" = "force" ]]; then
 		warn "Firmware will be forcibly updated"
 	fi
+	if [[ "${_arg_patch_tensix_disable_count}" = "on" ]]; then
+		warn "Firmware bundle will be patched with tt-update-tensix-disable-count (tensix disable count: ${_arg_tensix_disable_count}) before flashing"
+	fi
 	if [[ "${_arg_install_metalium_models_container}" = "on" ]]; then
 		log "Metalium Models container will be installed"
 	fi
@@ -1395,6 +1400,19 @@ main() {
 		fi
 
 		verify_download "${FW_FILE}"
+
+		if [[ "${_arg_patch_tensix_disable_count}" = "on" ]]; then
+			log "Patching firmware bundle with tt-update-tensix-disable-count"
+			if ! command -v tt-update-tensix-disable-count &> /dev/null; then
+				error_exit "tt-update-tensix-disable-count is not installed or not in PATH. Please install it before attempting to patch the firmware bundle (pip install tt-update-tensix-disable-count)."
+			fi
+			# The tool is not idempotent and must not patch in place: input -> distinct
+			# output, run exactly once, then replace the bundle.
+			if ! tt-update-tensix-disable-count --input "${FW_FILE}" --output "${FW_FILE}.patched" --board P150A-1 --board P150B-1 --board P150C-1 --disable-count "${_arg_tensix_disable_count}"; then
+				error_exit "Failed to patch firmware bundle with tt-update-tensix-disable-count."
+			fi
+			mv "${FW_FILE}.patched" "${FW_FILE}"
+		fi
 
 		if [[ "${_arg_update_firmware}" = "force" ]]; then
 			tt-flash flash "${FW_FILE}" --force

--- a/tests/test-i121-tensix-disable-patch.sh
+++ b/tests/test-i121-tensix-disable-patch.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# Host unit test for issue #121: "Add option to run
+# tt-update-tensix-disable-count on firmware before install".
+#
+# Covers the --patch-tensix-disable-count / --tensix-disable-count handling in
+# install.m4's firmware block:
+#   (a) flag on  -> tool invoked exactly once with the expected argv and the
+#                   patched bundle (not the original) is flashed;
+#   (b) flag off -> original bundle flashed, tool never invoked;
+#   (c) flag on but the tool is not on PATH -> installer error_exits before
+#       any flashing.
+#
+# The patch contract this guards: the tool is NOT idempotent, so install.m4
+# must run it exactly once, input -> distinct output file, then mv over the
+# bundle. Assertions are on argv and file identity (marker content), never on
+# bundle bytes/sizes/hashes (the real tool re-encodes the whole bundle and
+# output sizes vary between runs).
+#
+# Fully self-contained and non-destructive: curl/tt-flash/
+# tt-update-tensix-disable-count are mocked on a sandboxed PATH and the
+# firmware block is sourced verbatim from install.m4 (no argbash needed).
+# No network, no root, no device access.
+#
+# Run from anywhere:  bash tests/test-i121-tensix-disable-patch.sh
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SB="$(mktemp -d)"
+trap 'rm -rf "${SB}"' EXIT
+mkdir -p "${SB}/bin" "${SB}/bin-notool" "${SB}/work"
+
+fails=0
+ok()  { echo "ok     - $1"; }
+bad() { echo "NOT OK - $1"; fails=$((fails + 1)); }
+
+# --- mocks ---------------------------------------------------------------
+
+cat > "${SB}/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+# mock curl -O: write a fake bundle named after the URL basename into cwd
+for a in "$@"; do
+	case "${a}" in
+		http*) printf 'original-bundle\n' > "${a##*/}" ;;
+	esac
+done
+exit 0
+EOF
+
+cat > "${SB}/bin/tt-flash" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$@" > "${TTFLASH_ARGV}"
+exit 0
+EOF
+
+cat > "${SB}/bin/tt-update-tensix-disable-count" <<'EOF'
+#!/usr/bin/env bash
+# mock patch tool: record argv, then copy --input to --output and append a
+# marker (the real tool re-encodes; identity of content is all we assert)
+printf '%s\n' "$@" > "${TDC_ARGV}"
+in=""; out=""; prev=""
+for a in "$@"; do
+	case "${prev}" in
+		--input) in="${a}" ;;
+		--output) out="${a}" ;;
+	esac
+	prev="${a}"
+done
+[[ -n "${in}" && -n "${out}" ]] || exit 2
+cp "${in}" "${out}" && echo "patched-by-mock" >> "${out}"
+EOF
+
+chmod +x "${SB}/bin/"*
+cp "${SB}/bin/curl" "${SB}/bin/tt-flash" "${SB}/bin-notool/"
+
+# --- extract the firmware block verbatim from the tracked source ----------
+
+FW_BLOCK="${SB}/fw-block.sh"
+sed -n '/^\t# Update firmware using tt-flash$/,/^\tfi$/p' "${REPO_ROOT}/install.m4" > "${FW_BLOCK}"
+grep -q 'tt-update-tensix-disable-count --input' "${FW_BLOCK}" || { echo "BAIL OUT - could not extract firmware block (or patch handling missing) from install.m4"; exit 99; }
+
+# Minimal environment matching install.sh's shell semantics.
+log()   { echo "[info] $*"; }
+warn()  { echo "[warn] $*"; }
+error_exit() { echo "[error] $*" >&2; exit 1; }
+verify_download() { [[ -f "$1" ]]; }
+fetch_latest_version() { echo "0.0.0-mock"; }
+
+# Runs the extracted firmware block in a subshell with mocks on PATH.
+# Caller sets: _arg_update_firmware _arg_patch_tensix_disable_count
+# _arg_tensix_disable_count WORKDIR TDC_ARGV TTFLASH_ARGV FW_DIR (path with/without the tool)
+run_fw_block() { (
+	set -o pipefail
+	# shellcheck source=/dev/null
+	PATH="${FW_DIR}:/usr/bin:/bin"
+	cd "${WORKDIR}"
+	source "${FW_BLOCK}"
+); }
+
+export TDC_ARGV TTFLASH_ARGV # mocks are child processes; they read these
+
+FWV=9.9.9
+FW_FILE="fw_pack-${FWV}.fwbundle"
+
+# --- case (a): flag on -> patch exactly once, flash the patched bundle ----
+
+W="${SB}/case-a"; mkdir -p "${W}"
+WORKDIR="${W}"
+TDC_ARGV="${W}/tdc.argv"; TTFLASH_ARGV="${W}/ttflash.argv"
+_arg_update_firmware="force"
+_arg_patch_tensix_disable_count="on"
+_arg_tensix_disable_count="5" # non-default: proves value passthrough
+_arg_fw_version="${FWV}"
+FW_DIR="${SB}/bin"
+run_fw_block >"${W}/out.log" 2>&1
+rc=$?
+
+cat > "${W}/tdc.expected" <<EOF
+--input
+${FW_FILE}
+--output
+${FW_FILE}.patched
+--board
+P150A-1
+--board
+P150B-1
+--board
+P150C-1
+--disable-count
+5
+EOF
+cat > "${W}/ttflash.expected" <<EOF
+flash
+${FW_FILE}
+--force
+EOF
+
+[[ ${rc} -eq 0 ]] && ok "flag on: firmware block succeeds (rc=0)" || bad "flag on: rc=${rc}"
+diff -u "${W}/tdc.expected" "${W}/tdc.argv" >/dev/null 2>&1 \
+	&& ok "flag on: tool argv exact (input->${FW_FILE}.patched, 3 boards, --disable-count 5, single invocation)" \
+	|| bad "flag on: tool argv mismatch: $(tr '\n' ' ' < "${W}/tdc.argv" 2>/dev/null)"
+diff -u "${W}/ttflash.expected" "${W}/ttflash.argv" >/dev/null 2>&1 \
+	&& ok "flag on: flashed with --force" || bad "flag on: tt-flash argv: $(tr '\n' ' ' < "${W}/ttflash.argv" 2>/dev/null)"
+grep -q 'patched-by-mock' "${W}/${FW_FILE}" \
+	&& ok "flag on: flashed file IS the patched output (mv replaced the bundle)" \
+	|| bad "flag on: flashed bundle was not the patched one"
+[[ ! -e "${W}/${FW_FILE}.patched" ]] \
+	&& ok "flag on: no .patched leftover" || bad "flag on: ${FW_FILE}.patched still exists"
+
+# --- case (b): flag off -> original flashed, tool never invoked -----------
+
+W="${SB}/case-b"; mkdir -p "${W}"
+WORKDIR="${W}"
+TDC_ARGV="${W}/tdc.argv"; TTFLASH_ARGV="${W}/ttflash.argv"
+_arg_update_firmware="on"
+_arg_patch_tensix_disable_count="off"
+_arg_tensix_disable_count="0"
+_arg_fw_version="${FWV}"
+FW_DIR="${SB}/bin" # tool IS available and must still not run
+run_fw_block >"${W}/out.log" 2>&1
+rc=$?
+
+[[ ${rc} -eq 0 ]] && ok "flag off: firmware block succeeds (rc=0)" || bad "flag off: rc=${rc}"
+[[ ! -e "${W}/tdc.argv" ]] \
+	&& ok "flag off: tool never invoked" || bad "flag off: tool ran: $(tr '\n' ' ' < "${W}/tdc.argv")"
+printf 'flash\n%s\n' "${FW_FILE}" > "${W}/ttflash.expected"
+diff -u "${W}/ttflash.expected" "${W}/ttflash.argv" >/dev/null 2>&1 \
+	&& ok "flag off: original flashed (no --force)" || bad "flag off: tt-flash argv: $(tr '\n' ' ' < "${W}/ttflash.argv" 2>/dev/null)"
+cmp -s <(printf 'original-bundle\n') "${W}/${FW_FILE}" \
+	&& ok "flag off: flashed bundle is the untouched original" || bad "flag off: flashed bundle was modified"
+
+# --- case (c): flag on, tool missing -> error_exit, no flash --------------
+
+W="${SB}/case-c"; mkdir -p "${W}"
+WORKDIR="${W}"
+TDC_ARGV="${W}/tdc.argv"; TTFLASH_ARGV="${W}/ttflash.argv"
+_arg_update_firmware="force"
+_arg_patch_tensix_disable_count="on"
+_arg_tensix_disable_count="0"
+_arg_fw_version="${FWV}"
+FW_DIR="${SB}/bin-notool" # no tt-update-tensix-disable-count here
+run_fw_block >"${W}/out.log" 2>&1
+rc=$?
+
+[[ ${rc} -ne 0 ]] && ok "tool missing: installer fails (rc=${rc})" || bad "tool missing: rc=0, expected failure"
+grep -q 'tt-update-tensix-disable-count is not installed or not in PATH' "${W}/out.log" \
+	&& ok "tool missing: error names the tool and the pip install hint" || bad "tool missing: unexpected error output"
+[[ ! -e "${W}/ttflash.argv" ]] \
+	&& ok "tool missing: nothing was flashed" || bad "tool missing: tt-flash ran anyway"
+
+if [[ ${fails} -eq 0 ]]; then
+	echo "I121_UNIT: PASS - firmware-block patch handling guards issue #121 (argv + patched-file identity, all 3 cases)"
+	exit 0
+fi
+echo "I121_UNIT: FAIL - ${fails} check(s) failed"
+exit 1


### PR DESCRIPTION
Closes #121.

## What

New installer options (both default to a no-op, so existing behavior is unchanged):
- `--patch-tensix-disable-count` — run `tt-update-tensix-disable-count` on the downloaded firmware bundle before flashing (Blackhole p150 only)
- `--tensix-disable-count <N>` — the Tensix disable count to write into the bundle (default 0)

When enabled, in the firmware block between `verify_download` and `tt-flash flash`:
- fails fast with a pip install hint if `tt-update-tensix-disable-count` is not in PATH (mirrors the existing tt-flash guard)
- runs the tool exactly once per download, into a distinct `${FW_FILE}.patched` output, and swaps it over the bundle on success — the tool is **not** idempotent, so it is never re-run and never writes in place (probe-verified)
- boards are hardcoded to `--board P150A-1 --board P150B-1 --board P150C-1` per the upstream tool recommendation; note the bundles also carry P300 left/right images, which this option does not touch

Also adds `tests/test-i121-tensix-disable-patch.sh` — a self-contained host test that extracts the firmware block verbatim from `install.m4` and drives it against mocked `tt-update-tensix-disable-count`/`tt-flash`/`curl` (3 cases / 12 checks: flag on → exact tool argv and the patched file is what gets flashed; flag off → tool never invoked, original flashed; tool missing → installer errors with the pip hint, nothing flashed) — plus README docs for the flags.

## Evidence (log basenames; verdicts as printed by those logs)

| Log | Result |
|---|---|
| `issue121_tensix-disable-count_first-probe.log` | `I121_FIRST_PROBE: VERDICT: PASS - tool installs, latest bundle downloads via install.m4 URL scheme, P150 boards present, patch of a COPY succeeds with tool self-verify; NO flashing performed` — tool 0.0.2, `fw_pack-19.13.2.fwbundle`, P150A-1/P150B-1/P150C-1 present; also printed: `NOT IDEMPOTENT ... patch must be applied EXACTLY ONCE to the freshly downloaded bundle` |
| `i121-build-test.log` | `I121_IMPLEMENT: VERDICT: PASS - build OK, shellcheck 0.9.0 clean, host test 12/12, flags render in --help` — includes `I121_UNIT: PASS` (12/12 checks) |
| `i121-verify.log` | independent re-run of all gates on the PR head: `GATE1(commit+diffstat)=PASS GATE2(shellcheck)=PASS GATE3(unit)=PASS GATE4(build+help)=PASS GATE5(real tool)=PASS`, final line `VERDICT: PASS` — GATE5 ran the exact shipped argv (single occurrence in `install.m4`) with real tool 0.0.2 against a copy of the real `fw_pack-19.13.2.fwbundle`: rc=0, input copy unchanged, distinct `.patched` output, `Verified product_spec_harvesting.tensix_disable_count is 0` for all three boards, no flashing |

Host-only change: no device access and no `tt-flash` invocation anywhere in the above.
