### PR TITLE
Add rustup installation for Debian 13 (trixie) and Ubuntu 24.04 (noble)

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -243,6 +243,11 @@ detect_distro() {
 	fi
 }
 
+# True when dotted version ${1} (e.g. VERSION_ID "24.04" or "13") is at least ${2}.
+version_at_least() {
+	[[ "$(printf '%s\n%s\n' "${2}" "${1}" | sort -V | head -n 1)" = "${2}" ]]
+}
+
 # Fetch the golden .ttis schema for this distro from the pinned
 # tt-sw-manifest release. The release publishes one asset per
 # distro/version named "<distro_id>-<version_id>.ttis", so we download that file
@@ -1173,12 +1178,22 @@ main() {
 	case "${DISTRO_ID}" in
 		"ubuntu")
 			apt_get update
-			apt_get install -y git python3-pip dkms cargo rustc pipx jq protobuf-compiler
+			if version_at_least "${VERSION_ID:-0}" 24.04; then
+				# rustup is packaged from noble on and conflicts with cargo/rustc, so it replaces them.
+				apt_get install -y git python3-pip dkms rustup pipx jq protobuf-compiler
+			else
+				apt_get install -y git python3-pip dkms cargo rustc pipx jq protobuf-compiler
+			fi
 			;;
 		"debian")
-			# On Debian, packaged cargo and rustc are very old. Users must install them another way.
 			apt_get update
-			apt_get install -y git python3-pip dkms pipx jq protobuf-compiler
+			if version_at_least "${VERSION_ID:-0}" 13; then
+				# From trixie on, rustup is packaged (and conflicts with the very old cargo/rustc).
+				apt_get install -y git python3-pip dkms rustup pipx jq protobuf-compiler
+			else
+				# On older Debian, packaged cargo and rustc are very old. Users must install them another way.
+				apt_get install -y git python3-pip dkms pipx jq protobuf-compiler
+			fi
 			;;
 		"fedora")
 			sudo dnf install -y git python3-pip python3-devel dkms cargo rust pipx jq protobuf-compiler
@@ -1193,7 +1208,7 @@ main() {
 			;;
 	esac
 
-	if [[ "${DISTRO_ID}" = "debian" ]]; then
+	if [[ "${DISTRO_ID}" = "debian" ]] && ! version_at_least "${VERSION_ID:-0}" 13; then
 		warn "rustc and cargo cannot be automatically installed on Debian. Ensure the latest versions are installed before continuing."
 		warn "If you are unsure how to do this, use rustup: https://rustup.rs/"
 	fi


### PR DESCRIPTION
`rustup` is now packaged in the official Ubuntu 24.04 (noble) and Debian 13 (trixie) repos (issue #111), and the distro package apt-declares `Conflicts: cargo/rustc` — so it must replace, not be appended to, cargo/rustc. The installer's base-package set therefore installs `rustup` in place of `cargo rustc` on Ubuntu >= 24.04 and Debian >= 13. Older suites are unchanged: Ubuntu < 24.04 keeps `cargo rustc` (rustup is not packaged there), and Debian < 13 keeps the existing manual-rustup warning. Fedora is untouched.

Gating uses a small `version_at_least` helper comparing `VERSION_ID` from the already-sourced os-release (handles dotted versions like 24.04).

Verified on this rig by running the generated installer's base-package path with the CI flag list (real `apt-get install`, not a simulation) in docker containers:

- ubuntu:24.04 — rustup 1.26.0 installed from distro apt and functional; cargo/rustc not installed
- debian:13 — rustup 1.27.1 installed and functional; cargo/rustc not installed; manual-rustup warning correctly absent
- ubuntu:22.04 (regression) — cargo 1.75.0 + rustc 1.75.0 installed and working; rustup absent
- debian:12 (regression) — no rust toolchain installed; manual-rustup warning intact

Log: `tt-installer-111-verify.log`, final line `VERDICT: PASS`.

Scope: the diff only touches base-package selection (plus the Debian warning gate); kmd/podman/metalium/sfpi paths are untouched and left to CI.

Closes #111.