### PR TITLE
Silence default-path log output

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -254,7 +254,6 @@ fetch_golden_schema() {
 	local dest="${WORKDIR}/${asset}"
 	local url="https://github.com/tenstorrent/tt-sw-manifest/releases/download/${TTIS_GOLDEN_VERSIONS_TAG}/${asset}"
 
-	log "Fetching golden versions from ${url}"
 	if ! curl -fsSL "${url}" -o "${dest}"; then
 		warn "No golden versions file for ${DISTRO_ID} ${VERSION_ID} in release ${TTIS_GOLDEN_VERSIONS_TAG}"
 		return 1
@@ -294,6 +293,19 @@ set_non_interactive_defaults() {
 	if [[ "${_arg_mode_non_interactive}" = "on" ]] && [[ "${_arg_reboot_option}" = "ask" ]]; then
 		_arg_reboot_option="never" # Do not reboot in non-interactive mode
 	fi
+}
+
+# True when the user explicitly passed the given option on the command line
+# (matches both "--opt" and "--opt=value" forms). Used to decide whether to
+# announce settings that happen to match the installer's defaults.
+arg_was_passed() {
+	local opt="$1" arg
+	for arg in "${ORIGINAL_ARGS[@]+"${ORIGINAL_ARGS[@]}"}"; do
+		if [[ "${arg}" == "${opt}" || "${arg}" == "${opt}="* ]]; then
+			return 0
+		fi
+	done
+	return 1
 }
 
 maybe_enable_default_mode() {
@@ -1085,13 +1097,13 @@ main() {
 		fi
 	done
 
-	# Select the version channel.
+	# Select the version channel. The default ('release') is applied silently;
+	# explicit non-default selections are logged.
 	case "${_arg_versions}" in
 		rolling)
 			log "Version channel: rolling — installing the latest available version of each component"
 			;;
 		release)
-			log "Version channel: release — pinning component versions to this installer's golden baseline (${TTIS_GOLDEN_VERSIONS_TAG})"
 			if fetch_golden_schema; then
 				ttis_import_versions "${GOLDEN_SCHEMA_FILE}"
 			else
@@ -1101,6 +1113,8 @@ main() {
 		*)
 			# A path to a .ttis file: full non-interactive import (used by CI/automation).
 			log "Version channel: importing state from ${_arg_versions}"
+			# shellcheck disable=SC2034
+			TTIS_VERBOSE=1
 			ttis_import "${_arg_versions}"
 			;;
 	esac
@@ -1113,11 +1127,15 @@ main() {
 	fi
 	unset _ver_var user_versions
 
+	# Remember whether non-interactive mode was requested explicitly, before
+	# maybe_enable_default_mode can turn it on as part of the default path.
+	user_non_interactive="${_arg_mode_non_interactive}"
 	maybe_enable_default_mode
 	log "Starting installation"
 
-	# Log special mode settings
-	if [[ "${_arg_mode_non_interactive}" = "on" ]]; then
+	# Log special mode settings. Values that merely match the installer's
+	# defaults are not announced; explicit user selections are.
+	if [[ "${user_non_interactive}" = "on" ]]; then
 		warn "Running in non-interactive mode"
 	fi
 	if [[ "${_arg_mode_container}" = "on" ]]; then
@@ -1135,7 +1153,7 @@ main() {
 	if [[ "${_arg_install_metalium_container}" = "off" ]]; then
 		warn "Metalium container installation will be skipped"
 	fi
-	if [[ "${_arg_install_forge_container}" = "off" ]]; then
+	if [[ "${_arg_install_forge_container}" = "off" ]] && arg_was_passed "--no-install-forge-container"; then
 		warn "Forge container installation will be skipped"
 	fi
 	if [[ "${_arg_install_sfpi}" = "off" ]]; then
@@ -1154,13 +1172,13 @@ main() {
 	if [[ "${_arg_update_firmware}" = "off" ]]; then
 		warn "Firmware update will be skipped"
 	fi
-	if [[ "${_arg_update_firmware}" = "force" ]]; then
+	if [[ "${_arg_update_firmware}" = "force" ]] && arg_was_passed "--update-firmware"; then
 		warn "Firmware will be forcibly updated"
 	fi
 	if [[ "${_arg_install_metalium_models_container}" = "on" ]]; then
 		log "Metalium Models container will be installed"
 	fi
-	if [[ "${_arg_use_uv}" = "on" ]]; then
+	if [[ "${_arg_use_uv}" = "on" ]] && arg_was_passed "--use-uv"; then
 		log "uv will be used instead of pip for package installation"
 	fi
 
@@ -1473,8 +1491,10 @@ main() {
 		log "Usage: tt-studio [arguments]"
 	fi
 
-	# Export state file if requested
+	# Export state file if requested (an explicit selection, so ttis output is shown)
 	if [[ -n "${_arg_export_schema:-}" ]]; then
+		# shellcheck disable=SC2034
+		TTIS_VERBOSE=1
 		ttis_resolve_versions
 		ttis_export "${_arg_export_schema}"
 	fi
@@ -1497,6 +1517,7 @@ main() {
 }
 
 # Start installation
+ORIGINAL_ARGS=("$@")
 main
 
 # ] <-- needed because of Argbash

--- a/ttis.sh
+++ b/ttis.sh
@@ -61,7 +61,9 @@ TTIS_IMPORTED_PACKAGES=()
 
 # ── Internal helpers ───────────────────────────────────────────────────────────
 
-_ttis_log()  { echo "[ttis] $*"; }
+# Informational output is silent by default so the installer's console stays
+# clean; the standalone CLI entry point sets TTIS_VERBOSE=1 to re-enable it.
+_ttis_log()  { if [[ -n "${TTIS_VERBOSE:-}" ]]; then echo "[ttis] $*"; fi; }
 _ttis_warn() { echo "[ttis] WARNING: $*" >&2; }
 _ttis_err()  { echo "[ttis] ERROR: $*" >&2; }
 
@@ -560,6 +562,7 @@ ttis_import_versions() {
 
 # ── CLI entry point ────────────────────────────────────────────────────────────
 if [[ "${BASH_SOURCE[0]:-}" == "${0}" ]]; then
+	TTIS_VERBOSE=1
 	case "${1:-}" in
 		validate) ttis_validate "${2:?Usage: ttis.sh validate <file>}" ;;
 		*) echo "Usage: ttis.sh validate <file>" >&2; exit 1 ;;


### PR DESCRIPTION
## Summary

Running the installer with defaults currently prints a wall of informational output (version channel banner, `[ttis]` state messages, and warnings about settings that are simply the defaults). This PR silences all of that on the default path while keeping every message for explicit, non-default selections — the underlying behavior is unchanged.

- **Version channel**: the default `release` channel pins golden versions silently (including the "Fetching golden versions from…" line). `--versions rolling` and `--versions <file.ttis>` still log their selection, and the "command-line versions take precedence" note still appears when version flags are passed.
- **`[ttis]` output**: `_ttis_log` is now gated on `TTIS_VERBOSE`. The installer sets it for explicit `.ttis` imports and `--export-schema`; the standalone CLI entry point sets it too, so `ttis.sh validate` output in CI is unchanged. Warnings/errors were never gated and still print.
- **Default-path mode messages**: "Running in non-interactive mode", "Forge container installation will be skipped", "Firmware will be forcibly updated", and the uv info line now fire only when the corresponding option was explicitly passed. Since these trigger values *are* the defaults, argbash alone can't distinguish "default" from "explicitly chose the default", so a new `arg_was_passed()` helper scans the captured original command line (handles both `--opt value` and `--opt=value`). Non-interactive mode is snapshotted before `maybe_enable_default_mode`, so accepting the default-install prompt stays quiet while an explicit `--mode-non-interactive` still warns.

## Testing

- `make install.sh` builds cleanly; `bash -n` passes on the template, generated script, and `ttis.sh`
- `shellcheck -x install.m4` and `shellcheck ttis.sh` add no findings beyond main (the `TTIS_VERBOSE` assignments carry `disable=SC2034` since the consumer lives in sourced/inlined ttis.sh)
- Verified standalone `ttis.sh validate` still prints its result while the same function is silent when sourced
- Unit-tested `arg_was_passed` matching, including empty/unset args under `set -u`

🤖 Generated with [Claude Code](https://claude.com/claude-code)