### PR TITLE
Release-pipeline supply-chain hardening: pinning, attestation, reproducibility

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+# Keeps the SHA-pinned GitHub Actions current: Dependabot opens PRs that bump
+# each pin to the new release's commit SHA and updates the "# vX.Y.Z" comment,
+# so pinning stays reviewable instead of going stale.
+#
+# NOT covered here: the argbash build-container digest pin in
+# scripts/build-install-sh.sh — Dependabot does not watch `docker run` lines.
+# Update that pin manually and deliberately.
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/build-test-installer.yml
+++ b/.github/workflows/build-test-installer.yml
@@ -7,15 +7,17 @@ on:
   pull_request:
     branches: [ main ]
 
+# Read-only by default; jobs that need more (create-release) grant it explicitly.
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build installer
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -30,31 +32,14 @@ jobs:
           echo "tag_version=$TAG_VERSION" >> $GITHUB_OUTPUT
           echo "clean_version=$CLEAN_VERSION" >> $GITHUB_OUTPUT
 
-      - name: Set version in install.m4
-        run: |
-          # Replace the placeholder with actual version
-          # Use | as a delimited because / can sometimes show up in the input
-          sed -i "s|__INSTALLER_DEVELOPMENT_BUILD__|${{ steps.version.outputs.clean_version }}|g" install.m4
-          # Display the change for verification in workflow logs
-          echo "Updated install.m4 with version ${{ steps.version.outputs.clean_version }}"
-
-      - name: Generate install.sh from install.m4
-        run: |
-          docker run --rm \
-            -e PROGRAM=argbash \
-            -v "$(pwd):/work" \
-            -u "$(id -u):$(id -g)" \
-            matejak/argbash \
-            install.m4 -o install.sh
-
-      - name: Inline ttis.sh into install.sh
-        run: |
-          # The released install.sh must be self-contained so it runs via
-          # `bash -c "$(curl ... install.sh)"` with no second file to fetch.
-          scripts/inline-ttis.sh install.sh ttis.sh
+      - name: Build install.sh
+        # Stamps the version, compiles with a digest-pinned argbash image, and
+        # inlines ttis.sh. Kept in a script so scripts/reproduce-release.sh can
+        # rebuild release assets byte-for-byte from the tagged source.
+        run: scripts/build-install-sh.sh "${{ steps.version.outputs.clean_version }}"
 
       - name: Upload install.sh as artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: install-script
           path: install.sh
@@ -67,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install jq
         run: sudo apt-get install -y jq
@@ -147,10 +132,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Download install.sh
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: install-script
 
@@ -191,10 +176,10 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Download install.sh
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: install-script
 
@@ -307,7 +292,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Test template syntax
       run: |
@@ -320,10 +305,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Download install.sh
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: install-script
 
@@ -340,10 +325,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Download install.sh
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: install-script
 
@@ -411,19 +396,19 @@ jobs:
       contents: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           # Checkout the tag that triggered the original workflow
           ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Download artifacts from build workflow
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: install-script
 
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@v5
+        uses: mikepenz/release-changelog-builder-action@c9dc8369bccbc41e0ac887f8fd674f5925d315f7 # v5.4.1
         with:
           mode: "HYBRID" # Include both PRs and direct commits
           configurationJSON: |
@@ -443,7 +428,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           files: |
             install.sh

--- a/.github/workflows/build-test-installer.yml
+++ b/.github/workflows/build-test-installer.yml
@@ -401,8 +401,11 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
-          # Checkout the tag that triggered the original workflow
-          ref: ${{ github.event.workflow_run.head_sha }}
+          # Pin the checkout to the exact commit the triggering tag pointed at
+          # when the run started. (The previous `workflow_run.head_sha` here was
+          # always empty on this push-triggered workflow, silently falling back
+          # to the default ref.)
+          ref: ${{ github.sha }}
 
       - name: Download artifacts from build workflow
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/build-test-installer.yml
+++ b/.github/workflows/build-test-installer.yml
@@ -393,7 +393,10 @@ jobs:
     needs: [build, validate-golden, test-debian-ubuntu, test-fedora, test-hosted-n150, test-debian-ubuntu-rolling, test-action-container, test-version-precedence]
 
     permissions:
-      contents: write
+      contents: write      # create the release and upload assets
+      id-token: write      # sign the provenance attestation (Sigstore)
+      attestations: write  # store the attestation on the repo
+      pull-requests: read  # changelog builder lists merged PRs
     steps:
       - name: Checkout code
         uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
@@ -406,6 +409,23 @@ jobs:
         with:
           name: install-script
 
+      - name: Generate SHA256SUMS
+        run: |
+          sha256sum install.sh ttis.sh > SHA256SUMS
+          cat SHA256SUMS
+
+      - name: Attest build provenance
+        # Binds each asset's SHA-256 to this repo, commit, and workflow run via
+        # Sigstore, so `gh attestation verify <asset> --repo <this repo>` proves
+        # the asset was built here from the tagged commit — and a silently
+        # replaced release asset fails verification.
+        uses: actions/attest-build-provenance@4d101475d8b20a2381f78447822ac1eab6504dd8 # v4.2.2
+        with:
+          subject-path: |
+            install.sh
+            ttis.sh
+            SHA256SUMS
+
       - name: Build Changelog
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@c9dc8369bccbc41e0ac887f8fd674f5925d315f7 # v5.4.1
@@ -413,7 +433,7 @@ jobs:
           mode: "HYBRID" # Include both PRs and direct commits
           configurationJSON: |
             {
-              "template": "#{{CHANGELOG}}\n\n## Contributors\n#{{CONTRIBUTORS}}\n\n## Installation\n\nInstall this version with:\n```bash\n/bin/bash -c \"$(curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/install.sh)\"\n```\n\nLatest version can always be installed using:\n```bash\n/bin/bash -c \"$(curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh)\"\n```",
+              "template": "#{{CHANGELOG}}\n\n## Contributors\n#{{CONTRIBUTORS}}\n\n## Installation\n\nInstall this version with:\n```bash\n/bin/bash -c \"$(curl -fsSL https://github.com/${{ github.repository }}/releases/download/${{ github.ref_name }}/install.sh)\"\n```\n\nLatest version can always be installed using:\n```bash\n/bin/bash -c \"$(curl -fsSL https://github.com/${{ github.repository }}/releases/latest/download/install.sh)\"\n```\n\n## Verifying assets\n\nEvery asset carries a signed [build provenance attestation](https://github.com/${{ github.repository }}/attestations) binding it to this repository, the release workflow, and the tagged commit. To verify a downloaded asset:\n```bash\ngh attestation verify install.sh --repo ${{ github.repository }}\nsha256sum --check --ignore-missing SHA256SUMS\n```",
               "categories": [
                 {
                   "title": "## 🔄 Changes",
@@ -433,6 +453,7 @@ jobs:
           files: |
             install.sh
             ttis.sh
+            SHA256SUMS
           body: ${{ steps.build_changelog.outputs.changelog }}
           draft: false
           prerelease: false

--- a/.github/workflows/build-test-installer.yml
+++ b/.github/workflows/build-test-installer.yml
@@ -233,11 +233,16 @@ jobs:
         echo "override=${override}" >> "$GITHUB_OUTPUT"
 
     - name: Run installer with --versions=release and an explicit --smi-version
+      # --use-uv makes this job also cover the pinned uv install: install_uv
+      # downloads the pinned uv-installer.sh from GitHub and verifies it
+      # against UV_INSTALLER_SHA256, so a stale hash (e.g. a bad bump-uv) or a
+      # tampered asset fails here instead of on a user's machine.
       run: |
         set -euo pipefail
         timeout 900 bash install.sh \
           --mode-container \
           --mode-non-interactive \
+          --use-uv \
           --versions=release \
           --smi-version=${{ steps.pick.outputs.override }} \
           --update-firmware=off \

--- a/.github/workflows/build-test-installer.yml
+++ b/.github/workflows/build-test-installer.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -39,7 +39,7 @@ jobs:
         run: scripts/build-install-sh.sh "${{ steps.version.outputs.clean_version }}"
 
       - name: Upload install.sh as artifact
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: install-script
           path: install.sh
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install jq
         run: sudo apt-get install -y jq
@@ -132,10 +132,10 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
     - name: Checkout code
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Download install.sh
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: install-script
 
@@ -176,10 +176,10 @@ jobs:
     timeout-minutes: 30
     steps:
     - name: Checkout code
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Download install.sh
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: install-script
 
@@ -297,7 +297,7 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Test template syntax
       run: |
@@ -310,10 +310,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Download install.sh
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: install-script
 
@@ -330,10 +330,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Download install.sh
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: install-script
 
@@ -404,7 +404,7 @@ jobs:
       pull-requests: read  # changelog builder lists merged PRs
     steps:
       - name: Checkout code
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           # Pin the checkout to the exact commit the triggering tag pointed at
           # when the run started. (The previous `workflow_run.head_sha` here was
@@ -413,7 +413,7 @@ jobs:
           ref: ${{ github.sha }}
 
       - name: Download artifacts from build workflow
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: install-script
 
@@ -436,7 +436,7 @@ jobs:
 
       - name: Build Changelog
         id: build_changelog
-        uses: mikepenz/release-changelog-builder-action@c9dc8369bccbc41e0ac887f8fd674f5925d315f7 # v5.4.1
+        uses: mikepenz/release-changelog-builder-action@c9bcd8238b6f41e05561348339429d360b1c0247 # v6.2.3
         with:
           mode: "HYBRID" # Include both PRs and direct commits
           configurationJSON: |
@@ -456,7 +456,7 @@ jobs:
 
       - name: Create Release
         id: create_release
-        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3.0.2
         with:
           files: |
             install.sh

--- a/.github/workflows/golden-matrix.yml
+++ b/.github/workflows/golden-matrix.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
       - name: Install jq
         run: sudo apt-get install -y jq

--- a/.github/workflows/golden-matrix.yml
+++ b/.github/workflows/golden-matrix.yml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install jq
         run: sudo apt-get install -y jq

--- a/.github/workflows/test-debian-ubuntu.yml
+++ b/.github/workflows/test-debian-ubuntu.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Download install.sh
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/test-debian-ubuntu.yml
+++ b/.github/workflows/test-debian-ubuntu.yml
@@ -28,10 +28,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Download install.sh
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/test-fedora.yml
+++ b/.github/workflows/test-fedora.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Download install.sh
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/test-fedora.yml
+++ b/.github/workflows/test-fedora.yml
@@ -26,10 +26,10 @@ jobs:
 
     steps:
     - name: Checkout code
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Download install.sh
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/test-hosted-n150.yml
+++ b/.github/workflows/test-hosted-n150.yml
@@ -28,10 +28,10 @@ jobs:
         sudo apt-get purge -y docker-ce docker-ce-cli containerd.io
 
     - name: Checkout code
-      uses: actions/checkout@v4
+      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
 
     - name: Download install.sh
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
       with:
         name: ${{ inputs.artifact_name }}
 

--- a/.github/workflows/test-hosted-n150.yml
+++ b/.github/workflows/test-hosted-n150.yml
@@ -28,10 +28,10 @@ jobs:
         sudo apt-get purge -y docker-ce docker-ce-cli containerd.io
 
     - name: Checkout code
-      uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
     - name: Download install.sh
-      uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+      uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: ${{ inputs.artifact_name }}
 

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,11 @@ fetch-golden:
 			curl -fsSL -o "installer-golden-versions/golden/$${name}" "$${url}"; \
 		done
 
+# Update the pinned uv version + installer hash in install.m4 (latest release
+# by default, or `make bump-uv UV_VERSION=0.12.5` for a specific one).
+bump-uv:
+	scripts/bump-uv.sh $(UV_VERSION)
+
 clean:
 	rm -rf install.sh install.sh.temp
 

--- a/README.md
+++ b/README.md
@@ -146,6 +146,16 @@ gh attestation verify install.sh --repo tenstorrent/tt-installer
 Verification fails if the asset was modified after the release workflow built
 it, or was built anywhere other than this repository's release pipeline.
 
+The build is also reproducible: the release pipeline compiles `install.m4`
+with a digest-pinned argbash image via `scripts/build-install-sh.sh`, so the
+assets can be rebuilt byte-for-byte from the tagged source and compared
+against the published release — no trust in GitHub's release storage or
+attestation infrastructure required:
+
+```bash
+scripts/reproduce-release.sh v<version>
+```
+
 ## Using in CI
 
 tt-installer ships a composite GitHub Action that installs the stack at a

--- a/README.md
+++ b/README.md
@@ -130,6 +130,22 @@ pinned version is below the installed one through `dnf downgrade` (dnf's
 
 Note that the installer requires superuser (sudo) permisssions to install packages, add DKMS modules, and configure hugepages.
 
+### Verifying release assets
+
+Every release asset (`install.sh`, `ttis.sh`, `SHA256SUMS`) is published with a
+signed [build provenance attestation](https://docs.github.com/en/actions/security-for-github-actions/using-artifact-attestations)
+that cryptographically binds the asset to this repository, its release
+workflow, and the tagged commit it was built from. To verify a download before
+running it:
+
+```bash
+curl -fsSLO https://github.com/tenstorrent/tt-installer/releases/latest/download/install.sh
+gh attestation verify install.sh --repo tenstorrent/tt-installer
+```
+
+Verification fails if the asset was modified after the release workflow built
+it, or was built anywhere other than this repository's release pipeline.
+
 ## Using in CI
 
 tt-installer ships a composite GitHub Action that installs the stack at a

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
 
     - name: Upload state file artifact
       if: ${{ inputs.upload-artifact == 'true' }}
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
       with:
         name: tt-installer-state
         path: ${{ steps.install.outputs.schema-path }}

--- a/action.yml
+++ b/action.yml
@@ -183,7 +183,7 @@ runs:
 
     - name: Upload state file artifact
       if: ${{ inputs.upload-artifact == 'true' }}
-      uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: tt-installer-state
         path: ${{ steps.install.outputs.schema-path }}

--- a/install.m4
+++ b/install.m4
@@ -133,6 +133,14 @@ NC='\033[0m' # No Color
 # matrix; the Golden Matrix CI workflow reads this value out of install.m4.
 readonly TTIS_GOLDEN_VERSIONS_TAG="v1.0.0"
 
+# Pinned uv release and the SHA-256 of that release's uv-installer.sh. The
+# installer script is verified against this hash before it runs (it in turn
+# verifies the uv binary against its own embedded checksums), so both values
+# must move together. Bump with `make bump-uv`, which cross-checks the hash
+# from two origins and refuses non-immutable upstream releases.
+readonly UV_VERSION="0.12.5"
+readonly UV_INSTALLER_SHA256="504511fbbbd811aeaba6738abc79408956b6c7da0ca35437b3dcc24a41efc111"
+
 # ttis.sh is inlined here at build time (see scripts/inline-ttis.sh), replacing
 # the placeholder line below with the body of ttis.sh between its TTIS_INLINE
 # markers. This keeps the released install.sh a single self-contained file so it
@@ -316,15 +324,25 @@ check_uv_installed() {
 	command -v uv &> /dev/null
 }
 
-# Install uv (used when --use-uv is set but uv is not already present)
+# Install uv (used when --use-uv is set but uv is not already present).
+# Fetches the pinned release's installer from GitHub (astral.sh is unreachable
+# from some networks, e.g. returns 403 behind restrictive egress) and verifies
+# it against UV_INSTALLER_SHA256 before running it; the installer then verifies
+# the uv binary against its own embedded checksums. A failed download falls
+# back to the same pinned version from PyPI via pipx (already a base package);
+# a hash mismatch means the script is not the one we pinned and is always a
+# hard error, never a fallback. Both paths install uv into ~/.local/bin.
 install_uv() {
-	log "Installing uv"
-	# astral.sh is unreachable from some networks (e.g. returns 403 behind
-	# restrictive egress); fall back to PyPI via pipx, which is already a
-	# base package. Both install uv into ~/.local/bin.
-	if ! curl -LsSf https://astral.sh/uv/install.sh | sh; then
-		warn "Could not fetch uv from astral.sh, installing from PyPI with pipx"
-		pipx install uv
+	log "Installing uv ${UV_VERSION}"
+	local uv_installer="${WORKDIR}/uv-installer.sh"
+	if curl -fsSL -o "${uv_installer}" \
+		"https://github.com/astral-sh/uv/releases/download/${UV_VERSION}/uv-installer.sh"; then
+		echo "${UV_INSTALLER_SHA256}  ${uv_installer}" | sha256sum --check --quiet - \
+			|| error_exit "uv installer failed SHA-256 verification (expected ${UV_INSTALLER_SHA256}); refusing to run it"
+		sh "${uv_installer}"
+	else
+		warn "Could not download the uv installer from GitHub, installing uv ${UV_VERSION} from PyPI with pipx"
+		pipx install "uv==${UV_VERSION}"
 	fi
 	# uv installs to ~/.local/bin by default; make it visible this session
 	export PATH="${HOME}/.local/bin:${PATH}"

--- a/scripts/build-install-sh.sh
+++ b/scripts/build-install-sh.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# build-install-sh.sh — produce the released, self-contained install.sh.
+#
+# This is the single source of truth for the release build: CI
+# (.github/workflows/build-test-installer.yml) and independent verifiers
+# (scripts/reproduce-release.sh) both call it, so a release asset can be
+# reproduced byte-for-byte from its tagged source.
+#
+# Steps:
+#   1. Stamp <version> into install.m4 (in place, replacing the
+#      __INSTALLER_DEVELOPMENT_BUILD__ placeholder)
+#   2. Compile install.m4 -> install.sh with argbash, pinned by image digest
+#   3. Inline ttis.sh so install.sh is a single file
+#
+# The build is deterministic: same source tree + same version string ->
+# byte-identical install.sh. Keep it that way — no timestamps, no
+# environment-dependent output.
+#
+# Usage: scripts/build-install-sh.sh <version>
+set -euo pipefail
+
+VERSION="${1:?Usage: build-install-sh.sh <version>}"
+
+# The argbash build container, pinned by digest. The tag is informational;
+# the digest is what Docker enforces. Update both together, deliberately —
+# Dependabot does not watch this pin.
+readonly ARGBASH_IMAGE="matejak/argbash:2.11.0@sha256:9d4cb031d9d7ea893dd84ac02d596bb32560725d6cd1cc19d8c8933019125148"
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+# Use | as the sed delimiter because / can show up in the version string
+sed -i "s|__INSTALLER_DEVELOPMENT_BUILD__|${VERSION}|g" install.m4
+echo "[INFO] Stamped install.m4 with version ${VERSION}"
+
+docker run --rm \
+	-e PROGRAM=argbash \
+	-v "$(pwd):/work" \
+	-u "$(id -u):$(id -g)" \
+	"${ARGBASH_IMAGE}" \
+	install.m4 -o install.sh
+echo "[INFO] Compiled install.m4 -> install.sh with ${ARGBASH_IMAGE}"
+
+# The released install.sh must be self-contained so it runs via
+# `bash -c "$(curl ... install.sh)"` with no second file to fetch.
+scripts/inline-ttis.sh install.sh ttis.sh

--- a/scripts/bump-uv.sh
+++ b/scripts/bump-uv.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# bump-uv.sh — update the pinned uv version and installer hash in install.m4.
+#
+# The committed UV_INSTALLER_SHA256 is the trust anchor for every user's uv
+# install (Astral publishes no checksum for uv-installer.sh itself), so this
+# script establishes it carefully:
+#   1. Resolve the target uv release (latest by default)
+#   2. Refuse releases that are not immutable on GitHub — pre-immutability
+#      release assets can be silently replaced upstream
+#   3. Download the installer from GitHub and hash it
+#   4. Cross-check against the second origin (astral.sh): two independent
+#      origins serving identical bytes is the anchor-establishment evidence.
+#      Unreachable astral.sh is a warning (some networks block it); a hash
+#      MISMATCH between origins is always a hard error.
+#   5. Rewrite UV_VERSION and UV_INSTALLER_SHA256 in install.m4
+#
+# Requirements: curl, jq, sha256sum.
+# Usage: scripts/bump-uv.sh [version]   (e.g. 0.12.5; default: latest)
+set -euo pipefail
+
+cd "$(dirname "${BASH_SOURCE[0]}")/.."
+
+VERSION="${1:-}"
+if [[ -z "${VERSION}" ]]; then
+	VERSION="$(curl -fsSL https://api.github.com/repos/astral-sh/uv/releases/latest | jq -r '.tag_name')"
+	echo "[INFO] Latest uv release: ${VERSION}"
+fi
+
+release_json="$(curl -fsSL "https://api.github.com/repos/astral-sh/uv/releases/tags/${VERSION}")" \
+	|| { echo "[ERROR] No uv release tagged '${VERSION}'" >&2; exit 1; }
+immutable="$(jq -r '.immutable // false' <<< "${release_json}")"
+if [[ "${immutable}" != "true" ]]; then
+	echo "[ERROR] uv release ${VERSION} is not immutable on GitHub; its assets" >&2
+	echo "[ERROR] can be silently replaced upstream. Pin a newer, immutable release." >&2
+	exit 1
+fi
+echo "[INFO] Release ${VERSION} is immutable"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+curl -fsSL -o "${workdir}/gh.sh" \
+	"https://github.com/astral-sh/uv/releases/download/${VERSION}/uv-installer.sh"
+gh_sum="$(sha256sum "${workdir}/gh.sh" | cut -d' ' -f1)"
+echo "[INFO] GitHub    uv-installer.sh: ${gh_sum}"
+
+if curl -fsSL -o "${workdir}/astral.sh" "https://astral.sh/uv/${VERSION}/install.sh"; then
+	astral_sum="$(sha256sum "${workdir}/astral.sh" | cut -d' ' -f1)"
+	echo "[INFO] astral.sh install.sh:    ${astral_sum}"
+	if [[ "${astral_sum}" != "${gh_sum}" ]]; then
+		echo "[ERROR] The two origins serve DIFFERENT installer scripts for ${VERSION}." >&2
+		echo "[ERROR] Do not pin either hash until this is understood." >&2
+		exit 1
+	fi
+	echo "[INFO] Cross-check passed: both origins agree"
+else
+	echo "[WARN] astral.sh unreachable from this network; skipping cross-check." >&2
+	echo "[WARN] Consider re-running from a network that can reach it." >&2
+fi
+
+sed -i \
+	-e "s|^readonly UV_VERSION=.*|readonly UV_VERSION=\"${VERSION}\"|" \
+	-e "s|^readonly UV_INSTALLER_SHA256=.*|readonly UV_INSTALLER_SHA256=\"${gh_sum}\"|" \
+	install.m4
+
+echo "[INFO] install.m4 updated:"
+grep -n '^readonly UV_VERSION=\|^readonly UV_INSTALLER_SHA256=' install.m4
+echo "[INFO] Review the diff, then commit. CI exercises the pinned install via --use-uv."

--- a/scripts/reproduce-release.sh
+++ b/scripts/reproduce-release.sh
@@ -38,16 +38,17 @@ fi
 
 echo "[INFO] Rebuilding install.sh from source"
 (cd "${workdir}/src" && scripts/build-install-sh.sh "${TAG#v}")
+(cd "${workdir}/src" && sha256sum install.sh ttis.sh > SHA256SUMS)
 
 echo "[INFO] Downloading published release assets"
 mkdir -p "${workdir}/released"
-for asset in install.sh ttis.sh; do
+for asset in install.sh ttis.sh SHA256SUMS; do
 	curl -fsSL -o "${workdir}/released/${asset}" \
 		"https://github.com/${REPO}/releases/download/${TAG}/${asset}"
 done
 
 errors=0
-for asset in install.sh ttis.sh; do
+for asset in install.sh ttis.sh SHA256SUMS; do
 	rebuilt_sum="$(sha256sum "${workdir}/src/${asset}" | cut -d' ' -f1)"
 	released_sum="$(sha256sum "${workdir}/released/${asset}" | cut -d' ' -f1)"
 	if [[ "${rebuilt_sum}" == "${released_sum}" ]]; then

--- a/scripts/reproduce-release.sh
+++ b/scripts/reproduce-release.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# SPDX-FileCopyrightText: © 2026 Tenstorrent AI ULC
+# SPDX-License-Identifier: Apache-2.0
+#
+# reproduce-release.sh — independently verify a release by rebuilding it.
+#
+# Clones the tagged source, rebuilds install.sh with the exact build recorded
+# at that tag (scripts/build-install-sh.sh, argbash pinned by digest), and
+# byte-compares the result against the published release assets. A match
+# proves the assets were built from the tagged source — with no trust in
+# GitHub's release storage or attestation infrastructure required.
+#
+# Complements (not replaces) attestation verification:
+#   gh attestation verify install.sh --repo tenstorrent/tt-installer
+#
+# Requirements: git, curl, docker, sha256sum.
+# Only tags that contain scripts/build-install-sh.sh are reproducible;
+# earlier releases were built with an unpinned argbash image.
+#
+# Usage: scripts/reproduce-release.sh <tag>   (e.g. v1.9.0)
+set -euo pipefail
+
+TAG="${1:?Usage: reproduce-release.sh <tag>}"
+REPO="${TT_INSTALLER_REPO:-tenstorrent/tt-installer}"
+
+workdir="$(mktemp -d)"
+trap 'rm -rf "${workdir}"' EXIT
+
+echo "[INFO] Cloning ${REPO} at ${TAG}"
+git -c advice.detachedHead=false clone --quiet --depth 1 --branch "${TAG}" \
+	"https://github.com/${REPO}.git" "${workdir}/src"
+
+if [[ ! -x "${workdir}/src/scripts/build-install-sh.sh" ]]; then
+	echo "[ERROR] ${TAG} predates scripts/build-install-sh.sh and is not reproducible" >&2
+	echo "[ERROR] (older releases were built with an unpinned argbash image)" >&2
+	exit 2
+fi
+
+echo "[INFO] Rebuilding install.sh from source"
+(cd "${workdir}/src" && scripts/build-install-sh.sh "${TAG#v}")
+
+echo "[INFO] Downloading published release assets"
+mkdir -p "${workdir}/released"
+for asset in install.sh ttis.sh; do
+	curl -fsSL -o "${workdir}/released/${asset}" \
+		"https://github.com/${REPO}/releases/download/${TAG}/${asset}"
+done
+
+errors=0
+for asset in install.sh ttis.sh; do
+	rebuilt_sum="$(sha256sum "${workdir}/src/${asset}" | cut -d' ' -f1)"
+	released_sum="$(sha256sum "${workdir}/released/${asset}" | cut -d' ' -f1)"
+	if [[ "${rebuilt_sum}" == "${released_sum}" ]]; then
+		echo "[OK]   ${asset}: rebuilt asset matches release (${released_sum})"
+	else
+		echo "[FAIL] ${asset}: MISMATCH" >&2
+		echo "       rebuilt:  ${rebuilt_sum}" >&2
+		echo "       released: ${released_sum}" >&2
+		errors=$((errors + 1))
+	fi
+done
+
+if [[ "${errors}" -gt 0 ]]; then
+	echo "[ERROR] ${TAG}: release assets do NOT match a rebuild from the tagged source" >&2
+	exit 1
+fi
+echo "[INFO] ${TAG}: all assets reproduce byte-for-byte from the tagged source"


### PR DESCRIPTION
Addresses three of the four pieces of release-process security feedback (the fourth — unpinned `git clone`s of tt-studio/tt-inference-server — is tracked separately: they'll be packaged and added to the golden `.ttis`).

## 1. Pinned Actions and build container (`c4af2c5`)

- Every third-party action is pinned to a full commit SHA (with a `# vX.Y.Z` comment) instead of a mutable tag, across all workflows and `action.yml`. `softprops/action-gh-release` bumped v1 → v2.6.2; the stray `checkout@v3` aligned to v4.4.0.
- The release build compiles `install.m4` with `matejak/argbash` pinned **by digest** (was implicit `:latest`, a mutable third-party Docker Hub image). Currently `latest` == `2.11.0`, so this freezes existing behavior. The pin lives in the new `scripts/build-install-sh.sh`, the single source for the release build.
- Workflow token defaults to `contents: read`; only `create-release` gets write (the build job never needed it).
- Dependabot (github-actions ecosystem, weekly, grouped) keeps the pins current via reviewable PRs. Note: Dependabot does not watch `docker run` lines — the argbash digest is a deliberate manual bump.

## 2. Provenance attestation + checksums (`11551d6`)

- `create-release` runs `actions/attest-build-provenance` over `install.sh`, `ttis.sh`, and a new `SHA256SUMS` asset. The Sigstore attestation binds each asset's SHA-256 to this repo, the release workflow, and the tagged commit:
  ```bash
  gh attestation verify install.sh --repo tenstorrent/tt-installer
  ```
  A silently replaced release asset now fails verification.
- Verification instructions added to the release body template and README.

**Maintainer follow-up (repo settings, not code):** enable **immutable releases** and add a `v*` tag ruleset (no deletion/moving). Attestation makes tampering detectable; the setting makes it impossible.

## 3. Signed-commit → asset chain (`3856b52`)

- Fixed a latent bug: `create-release` checked out `github.event.workflow_run.head_sha`, which is **always empty** on this push-triggered workflow — the "check out the exact tag commit" intent was silently not in force. Now `github.sha`.
- New `scripts/reproduce-release.sh <tag>`: rebuilds `install.sh` from the tagged source with the build recorded at that tag and byte-compares against the published assets — an attestation-independent proof that assets came from the signed tag. Verified: two independent rebuilds produce byte-identical output; pre-pinning tags (e.g. v3.5.4) are cleanly reported as non-reproducible.

## 4. uv pinned by version + installer hash (`f34a7d1`)

- `install.m4` pins `UV_VERSION` + `UV_INSTALLER_SHA256`, replacing unpinned `curl astral.sh/uv/install.sh | sh`. The installer script is fetched from the GitHub release (also fixes the hosted-N150 astral.sh 403), verified against the pinned hash, then run; it self-verifies the uv binary against its embedded checksums. Failed download → pinned pipx fallback (`uv==${UV_VERSION}`); hash mismatch → hard error, never a fallback.
- `make bump-uv [UV_VERSION=x.y.z]` automates updates: refuses upstream releases that are not immutable on GitHub (pre-immutability assets can be silently replaced — e.g. 0.8.11 is refused), and establishes the hash by cross-checking that GitHub and astral.sh serve identical bytes (Astral publishes no checksum for `uv-installer.sh` itself).
- The version-precedence job now passes `--use-uv`, so the pinned uv path — previously uncovered by CI — gates every release.

## Testing

- Full build via the digest-pinned image from fresh clones: deterministic (byte-identical `install.sh` across two independent rebuilds), version-stamped, `bash -n` clean.
- `install_uv` exercised in a sandboxed `$HOME`: happy path installs a working uv 0.12.5; tampered hash aborts before execution; failed download falls back to pinned pipx.
- `bump-uv`: rejects non-immutable 0.8.11, idempotently re-pins 0.12.5, two-origin cross-check agrees.
- All YAML parses; embedded changelog JSON valid; new scripts shellcheck-clean.
- The attestation/release path itself only fully exercises on the next `v*` tag — worth watching that run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)