### PR TITLE
fix(installer): disable firmware updates by default in container mode

### DIFF
--- a/install.m4
+++ b/install.m4
@@ -89,7 +89,8 @@ if [[ "${_arg_install_container_runtime}" = "no" ]]; then
 	_arg_install_container_runtime="none"
 fi
 
-# If container mode is enabled, disable KMD, HugePages, and SFPI
+# If container mode is enabled, disable KMD, HugePages, SFPI, and firmware
+# updates -- none of these are host-oriented actions a container should take
 # shellcheck disable=SC2154
 if [[ "${_arg_mode_container}" = "on" ]]; then
 	_arg_install_kmd="off"
@@ -97,6 +98,7 @@ if [[ "${_arg_mode_container}" = "on" ]]; then
 	_arg_install_container_runtime="none" # No container runtime in container
 	_arg_install_sfpi="off"
 	_arg_reboot_option="never" # Do not reboot
+	_arg_update_firmware="off" # Firmware lives on the host, not the container
 fi
 
 PIPX_ENSUREPATH_EXTRAS="${TT_PIPX_ENSUREPATH_EXTRAS:- }"


### PR DESCRIPTION
Fixes #156.

## Description

`--mode-container` disables several host-oriented installer actions --
KMD, HugePages, container runtime installation, SFPI, and reboot --
because none of them belong on a container. It did not disable
firmware updates, which stayed at their global default of `force`,
so a container-mode run would still forcibly update host firmware.

## Fix

Added `_arg_update_firmware="off"` to the same override block that
already handles the other host-only actions in `install.m4`, matching
the existing pattern exactly. Regenerated `install.sh` via
`make install.sh` to confirm the change propagates correctly.

`ttis.sh` does not implement `--mode-container` at all, so it is
unaffected by this bug and needs no change.

## Testing

Confirmed the generated `install.sh` sets `_arg_update_firmware="off"`
inside the container-mode block after the fix, matching the source
`install.m4` change. `make install.sh` completes cleanly with no
errors.