### PR TITLE
feat: add --dry-run mode for installer preview (Fixes #140)

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,3 +234,12 @@ For more information, please see this compatibility matrix:
 | Other RPM-based distros  | N/A          | N/A     | Unsupported but may work |
 | Arch Linux | N/A     | No       | Unsupported  |
 | NixOS      | N/A     | No       | Unsupported, but some TT software is in nixpkgs (unofficial, use at own risk) |
+
+
+
+### Dry-Run Mode
+
+To preview all actions the installer would perform without actually modifying your system, use the `--dry-run` flag:
+
+```bash
+./install.sh --dry-run


### PR DESCRIPTION
## Summary
This PR adds a `--dry-run` flag to the tt-installer that previews all actions without modifying the system.

## Changes
- Added `ARG_OPTIONAL_BOOLEAN([dry-run])` to `install.m4`
- Implemented `print_dry_run_preview()` function showing:
  - Operating System and architecture
  - Kernel version
  - Packages to be installed (KMD, HugePages, container runtime, etc.)
  - Container images (Metalium, Forge)
  - Firmware update policy
- Added early exit when `--dry-run` is passed, preventing any system modifications
- Updated README with usage documentation

## Testing
```bash
./install.sh --dry-run
```